### PR TITLE
Add GPT-powered match analysis generation

### DIFF
--- a/gpt_analysis.py
+++ b/gpt_analysis.py
@@ -1,0 +1,50 @@
+import logging
+import os
+from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+
+SYSTEM_PROMPT = (
+    "Ты профессиональный спортивный аналитик. "
+    "Пиши краткий, структурированный анализ предстоящего матча на русском. "
+    "Без ставок и гарантий, без токсичности. "
+    "Используй нейтральный тон и избегай выдуманных фактов, если данных нет."
+)
+
+
+async def generate_match_analysis(match):
+    """Сгенерировать анализ матча через GPT."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.warning("OPENAI_API_KEY не задан, анализ не будет сгенерирован.")
+        return None
+    client = AsyncOpenAI(api_key=api_key)
+    prompt = (
+        "Сгенерируй анализ предстоящего матча.\n"
+        f"Вид спорта: {match['sport']}\n"
+        f"Матч: {match['team1']} vs {match['team2']}\n"
+        f"Дата и время: {match['match_date']} {match['match_time']}\n\n"
+        "Нужен компактный аналитический обзор (6-10 пунктов), включая:\n"
+        "- форма команд и мотивация (без выдуманных конкретных фактов)\n"
+        "- стилистика игры и тактические особенности\n"
+        "- возможные ключевые факторы матча\n"
+        "- аккуратный прогноз динамики игры (без точного счета)\n"
+        "Заверши коротким выводом в 1-2 предложениях."
+    )
+    try:
+        response = await client.responses.create(
+            model=DEFAULT_MODEL,
+            input=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        )
+    except Exception as exc:
+        logger.error("Не удалось получить анализ от GPT: %s", exc)
+        return None
+    analysis_text = response.output_text
+    if not analysis_text:
+        return None
+    return analysis_text.strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot==22.6
 APScheduler==3.11.2
 pytz==2025.2
 tzlocal==5.3.1
+openai==1.55.3

--- a/user_handlers.py
+++ b/user_handlers.py
@@ -3,7 +3,7 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes, CallbackQueryHandler, CommandHandler
 import database
 import keyboards
-from utils import safe_edit_message, send_main_menu, format_match_info
+from utils import safe_edit_message, send_main_menu, format_match_info, get_or_generate_analysis
 from datetime import datetime, timedelta
 import urllib.parse
 
@@ -273,15 +273,21 @@ async def handle_match_detail(query, user_id, match_id):
         await safe_edit_message(query, "Матч не найден.",
                                 keyboards.main_menu_keyboard())
         return
+    analysis_text = match['analysis_text']
+    if not analysis_text:
+        analysis_text = await get_or_generate_analysis(match)
     has_purchased = database.has_purchased_analysis(user_id, match_id)
     user_balance = database.get_user_balance(user_id)
     text = format_match_info(match)
     if has_purchased:
-        text += f"\n📊 *Анализ:*\n{match['analysis_text']}\n\n"
+        if analysis_text:
+            text += f"\n📊 *Анализ:*\n{analysis_text}\n\n"
+        else:
+            text += "\n❌ Анализ для этого матча еще не готов.\n\n"
         text += f"✅ Вы уже приобрели этот анализ"
     else:
         text += f"\n💰 *Цена анализа:* {match['price']} руб.\n\n"
-        if match['analysis_text']:
+        if analysis_text:
             text += "Для просмотра анализа необходимо приобрести его."
         else:
             text += "❌ Анализ для этого матча еще не готов."
@@ -292,11 +298,12 @@ async def handle_match_detail(query, user_id, match_id):
         keyboard.append([InlineKeyboardButton("🏠 В главное меню",
                                               callback_data='back_to_menu')])
     else:
-        if user_balance >= match['price']:
-            keyboard.append([InlineKeyboardButton(f"✅ Купить анализ за {match['price']} руб.", callback_data=f'buy_{match_id}')])
-        else:
-            keyboard.append([InlineKeyboardButton("💳 Пополнить баланс",
-                                                  callback_data='deposit')])
+        if analysis_text:
+            if user_balance >= match['price']:
+                keyboard.append([InlineKeyboardButton(f"✅ Купить анализ за {match['price']} руб.", callback_data=f'buy_{match_id}')])
+            else:
+                keyboard.append([InlineKeyboardButton("💳 Пополнить баланс",
+                                                      callback_data='deposit')])
         keyboard.append([InlineKeyboardButton("◀️ Назад",
                                               callback_data='back')])
         keyboard.append([InlineKeyboardButton("🏠 В главное меню",
@@ -319,7 +326,10 @@ async def handle_purchase(query, user_id):
             keyboards.main_menu_keyboard()
         )
         return
-    if not match['analysis_text']:
+    analysis_text = match['analysis_text']
+    if not analysis_text:
+        analysis_text = await get_or_generate_analysis(match)
+    if not analysis_text:
         await safe_edit_message(
             query,
             "❌ Анализ для этого матча еще не готов.",
@@ -339,7 +349,7 @@ async def handle_purchase(query, user_id):
         text += f"🏆 Матч: {match['team1']} vs {match['team2']}\n"
         text += f"💰 Списано: {match['price']} руб.\n"
         text += f"💳 Новый баланс: {database.get_user_balance(user_id)} руб.\n\n"
-        text += f"📊 Анализ:\n{match['analysis_text']}"
+        text += f"📊 Анализ:\n{analysis_text}"
     else:
         text = f"❌ Не удалось купить анализ:\n{message}\n\n"
         text += f"💰 Ваш баланс: {database.get_user_balance(user_id)} руб.\n"

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import logging
 from telegram import Update
 from telegram.ext import ContextTypes
 import database
+from gpt_analysis import generate_match_analysis
 
 logger = logging.getLogger(__name__)
 
@@ -74,3 +75,13 @@ def format_match_info(match, include_analysis=False):
     if include_analysis and match['analysis_text']:
         text += f"\n📊 *Анализ:*\n{match['analysis_text']}\n"
     return text
+
+
+async def get_or_generate_analysis(match):
+    """Получить или сгенерировать анализ для матча."""
+    if match['analysis_text']:
+        return match['analysis_text']
+    analysis_text = await generate_match_analysis(match)
+    if analysis_text:
+        database.update_match_analysis(match['id'], analysis_text)
+    return analysis_text


### PR DESCRIPTION
### Motivation
- Автоматизировать генерацию аналитики матчей через нейросеть (GPT) чтобы бот мог предлагать анализы автоматически при просмотре и покупке матчей.
- Сохранить текущую архитектуру (локально, без серверов и БД-структурных изменений) и интегрировать нейросеть минимально инвазивно.

### Description
- Добавлен новый модуль `gpt_analysis.py` который использует `openai.AsyncOpenAI` (Responses API) для асинхронной генерации структурированного анализа с настраиваемой моделью через `OPENAI_MODEL` и ключом `OPENAI_API_KEY`.
- Добавлена функция `get_or_generate_analysis` в `utils.py`, которая получает существующий анализ из записи матча или запрашивает и кеширует его через `database.update_match_analysis` если его нет.
- Интеграция в пользовательские сценарии в `user_handlers.py`: при просмотре страницы матча и при попытке покупки анализ генерируется по запросу (если отсутствует) и отображается/используется в логике покупки и UI.
- Обновлены зависимости в `requirements.txt` с добавлением `openai==1.55.3`.

### Testing
- Автоматические тесты не запускались в этом релизе (нет покрывающих CI-проверок в репозитории), изменения были проверены на предмет успешного применения патчей и коммитов локально.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839f46a60c83338e1aa0daf10c0399)