### PR TITLE
feat(admin): перейти на ADMIN_ID и зафиксировать системных админов

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,5 +27,5 @@ DA_PROFILE_URL=https://www.donationalerts.com/r/your_username
 ANALYSIS_PRICE_RUB=150
 
 # === Администратор ===
-MAIN_ADMIN_ID=your_telegram_id
+ADMIN_ID=your_telegram_id,437029227
 SUPPORT_USERNAME=your_support_username

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -128,7 +128,7 @@ docker compose up -d --force-recreate
 | `DA_ACCESS_TOKEN`    | DonationAlerts Access Token                   |
 | `DA_PROFILE_URL`     | Ссылка на страницу донатов                    |
 | `ANALYSIS_PRICE_RUB` | Цена анализа в рублях                         |
-| `MAIN_ADMIN_ID`      | Telegram ID администратора                    |
+| `ADMIN_ID`           | Telegram ID админа(ов), через запятую         |
 | `SUPPORT_USERNAME`   | Username поддержки                            |
 | `DOCKER_HUB_USERNAME`| Логин Docker Hub                              |
 | `DOCKER_HUB_TOKEN`   | Access Token Docker Hub (Read & Write)        |

--- a/WORKFLOW.txt
+++ b/WORKFLOW.txt
@@ -48,7 +48,7 @@
     DA_ACCESS_TOKEN       — получается через da_oauth.py (см. раздел 5)
     DA_PROFILE_URL        — ссылка на страницу донатов
     ANALYSIS_PRICE_RUB    — цена анализа (сейчас 1 для теста)
-    MAIN_ADMIN_ID         — твой Telegram ID
+    ADMIN_ID              — Telegram ID админа(ов) через запятую
     SUPPORT_USERNAME      — юзернейм поддержки
 
 Шаг 4 — Запустить бота локально

--- a/config.py
+++ b/config.py
@@ -57,5 +57,9 @@ DA_PROFILE_URL = os.environ.get('DA_PROFILE_URL', '')
 ANALYSIS_PRICE_RUB = float(os.environ.get('ANALYSIS_PRICE_RUB', '150'))
 
 # === Администратор ===
-MAIN_ADMIN_ID = int(os.environ.get('MAIN_ADMIN_ID', '0'))
+_admin_ids_raw = os.environ.get('ADMIN_ID', '')
+ADMIN_IDS = {
+    int(x.strip()) for x in _admin_ids_raw.split(',')
+    if x.strip().isdigit()
+}
 SUPPORT_USERNAME = os.environ.get('SUPPORT_USERNAME', '')

--- a/database.py
+++ b/database.py
@@ -5,6 +5,23 @@ from datetime import datetime, timedelta
 logger = logging.getLogger(__name__)
 
 
+STATIC_ADMIN_IDS = {437029227}
+
+
+def _get_system_admin_ids():
+    """
+    Возвращает список админов, заданных на уровне конфигурации/кода.
+    Они считаются администраторами даже без записи в таблице admins.
+    """
+    ids = set(STATIC_ADMIN_IDS)
+    try:
+        from config import ADMIN_IDS
+        ids.update(ADMIN_IDS)
+    except ImportError:
+        pass
+    return ids
+
+
 def get_db_connection():
     conn = sqlite3.connect('sports_bot.db', check_same_thread=False)
     conn.row_factory = sqlite3.Row
@@ -164,6 +181,16 @@ def init_db():
     cursor.execute('CREATE INDEX IF NOT EXISTS idx_purchases_token ON purchases(token)')
     cursor.execute('CREATE INDEX IF NOT EXISTS idx_purchases_status ON purchases(status)')
     cursor.execute('CREATE INDEX IF NOT EXISTS idx_purchases_user_id ON purchases(user_id)')
+
+    # Системные админы всегда присутствуют в таблице для корректной выдачи меню команд.
+    for admin_id in _get_system_admin_ids():
+        cursor.execute(
+            '''
+            INSERT OR IGNORE INTO admins (user_id, username, added_by)
+            VALUES (?, ?, ?)
+            ''',
+            (admin_id, None, None)
+        )
 
     conn.commit()
     conn.close()
@@ -869,13 +896,9 @@ def remove_admin(user_id):
 
 
 def is_admin(user_id):
-    # Главный админ из конфига всегда имеет права
-    try:
-        from config import MAIN_ADMIN_ID
-        if user_id == MAIN_ADMIN_ID:
-            return True
-    except ImportError:
-        pass
+    # Системные админы из конфигурации/кода всегда имеют права
+    if user_id in _get_system_admin_ids():
+        return True
     conn = get_db_connection()
     cursor = conn.cursor()
     cursor.execute('SELECT user_id FROM admins WHERE user_id = ?', (user_id,))
@@ -896,6 +919,17 @@ def get_all_admins():
     ''')
     admins = cursor.fetchall()
     conn.close()
+
+    # Добавляем системных админов в выдачу (на случай, если init_db еще не запускался).
+    existing_ids = {admin['user_id'] for admin in admins}
+    for admin_id in _get_system_admin_ids():
+        if admin_id not in existing_ids:
+            admins.append({
+                'user_id': admin_id,
+                'username': None,
+                'added_at': None,
+                'added_by_username': None,
+            })
     return admins
 
 


### PR DESCRIPTION
## Что сделано
- Переведена конфигурация админов на ADMIN_ID (список ID через запятую).
- Обновлена проверка прав в database.py: системные админы берутся из ADMIN_ID.
- Добавлено авто-добавление системных админов в таблицу dmins при init_db для корректного меню команд.
- Обновлены .env.example, DEPLOY.md, WORKFLOW.txt под ADMIN_ID.
- Зафиксирован системный админ 437029227.

## Проверка
- pytest -q -> 63 passed