### PR TITLE
feat(scheduler): auto-cleanup old analyses and expired topups

### DIFF
--- a/database.py
+++ b/database.py
@@ -735,7 +735,7 @@ def get_topup_by_token(token):
 
 
 def expire_pending_topups():
-    """Переводит истёкшие pending пополнения в статус expired."""
+    """Переводит истёкшие pending пополнения в expired и удаляет expired старше 12ч."""
     conn = get_db_connection()
     cursor = conn.cursor()
     now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -744,10 +744,21 @@ def expire_pending_topups():
         SET status = 'expired'
         WHERE status = 'pending' AND expires_at <= ?
     ''', (now,))
-    affected = cursor.rowcount
+    expired_count = cursor.rowcount
+
+    # Удаляем expired записи старше 12 часов
+    cutoff = (datetime.now() - timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')
+    cursor.execute('''
+        DELETE FROM balance_topups
+        WHERE status = 'expired' AND expires_at <= ?
+    ''', (cutoff,))
+    deleted_count = cursor.rowcount
+
     conn.commit()
     conn.close()
-    return affected
+    if deleted_count > 0:
+        logger.info(f"Удалено старых expired topups: {deleted_count}")
+    return expired_count
 
 
 def get_pending_topup_by_user(user_id):

--- a/main.py
+++ b/main.py
@@ -42,6 +42,22 @@ async def scheduled_sync_matches():
         logger.error("=" * 60, exc_info=True)
 
 
+async def scheduled_cleanup():
+    """Периодическая очистка старых покупок и матчей (1 день после матча)"""
+    from datetime import datetime
+    logger.info(f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ЗАПУСК очистки старых анализов...")
+    try:
+        expired_topups = database.expire_pending_topups()
+        deleted_purchases = database.cleanup_old_purchases()
+        deleted_matches = database.delete_finished_matches_without_purchases()
+        logger.info(
+            f"Очистка завершена: expired_topups={expired_topups}, "
+            f"покупок={deleted_purchases}, матчей={deleted_matches}"
+        )
+    except Exception as e:
+        logger.error(f"Ошибка очистки: {e}", exc_info=True)
+
+
 async def post_init(application):
     """Callback после инициализации бота (в контексте event loop)"""
     # Настройка APScheduler для периодической синхронизации
@@ -56,6 +72,15 @@ async def post_init(application):
         replace_existing=True
     )
 
+    # Очистка старых анализов каждые 6 часов
+    scheduler.add_job(
+        scheduled_cleanup,
+        trigger=IntervalTrigger(hours=6),
+        id='cleanup_old',
+        name='Очистка старых анализов',
+        replace_existing=True
+    )
+
     # Немедленная синхронизация при старте бота
     scheduler.add_job(
         scheduled_sync_matches,
@@ -63,9 +88,16 @@ async def post_init(application):
         name='Синхронизация при старте'
     )
 
+    # Немедленная очистка при старте
+    scheduler.add_job(
+        scheduled_cleanup,
+        id='cleanup_startup',
+        name='Очистка при старте'
+    )
+
     scheduler.start()
     logger.info("=" * 60)
-    logger.info("APScheduler запущен: синхронизация каждые 3 часа")
+    logger.info("APScheduler запущен: синхронизация каждые 3 часа, очистка каждые 6 часов")
     logger.info("=" * 60)
 
     # Сохраняем scheduler в bot_data для graceful shutdown


### PR DESCRIPTION
## Summary
- Добавлена автоматическая очистка старых покупок/матчей (>1 день) через APScheduler (при старте + каждые 6ч)
- `expire_pending_topups()` теперь также удаляет expired записи из `balance_topups` старше 12 часов
- Ранее очистка работала только через ручную админ-команду `/clean_matches`

## Test plan
- [ ] Запустить бота, убедиться что cleanup job отрабатывает при старте (в логах)
- [ ] Проверить что старые покупки и матчи удаляются корректно
- [ ] Проверить что expired topups старше 12ч удаляются из БД
