### PR TITLE
fix: flake8 E305 in config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,7 @@ def _env_to_bool(name: str, default: bool = False) -> bool:
         return default
     return raw.strip().lower() in ('1', 'true', 'yes', 'on')
 
+
 # === Telegram ===
 TOKEN = os.environ.get('TELEGRAM_TOKEN', '')
 


### PR DESCRIPTION
Добавлена недостающая пустая строка после функции _env_to_bool в config.py.
Исправлен CI-падеж lake8 по ошибке E305.