### PR TITLE
Fix DonationAlerts polling timeout and topup race

### DIFF
--- a/da_polling.py
+++ b/da_polling.py
@@ -37,7 +37,8 @@ def get_recent_donations(limit=10):
 
     response = requests.get(
         f'https://www.donationalerts.com/api/v1/alerts/donations?limit={limit}',
-        headers=headers
+        headers=headers,
+        timeout=15
     )
     response.raise_for_status()
     data = response.json()

--- a/database.py
+++ b/database.py
@@ -1023,11 +1023,17 @@ def complete_balance_topup(topup_id, donation_event_id, received_amount_rub=None
             else topup['amount_rub']
         )
 
+        # Атомарный захват: только один процесс переведёт pending → paid
         cursor.execute('''
             UPDATE balance_topups
             SET status = 'paid', donation_event_id = ?, amount_rub = ?
-            WHERE id = ?
+            WHERE id = ? AND status = 'pending'
         ''', (donation_event_id, amount_to_credit, topup_id))
+
+        if cursor.rowcount == 0:
+            # Другой процесс уже обработал этот topup
+            conn.commit()
+            return False
 
         cursor.execute('''
             UPDATE users SET balance = COALESCE(balance, 0) + ?


### PR DESCRIPTION
## Что сделано
- добавлен timeout=15 в запрос DonationAlerts polling
- устранена гонка при complete_balance_topup через атомарный захват pending topup

## Проверка
- python -m pytest -q
- 207 passed