### PR TITLE
Improve sync coverage rechecks and reduce H2H log noise

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,8 @@ def _sync_matches_job():
 
     syncer = SportsDBSyncer(
         mode='top3',
-        limit=15
+        limit=15,
+        min_coverage_rows=6
     )
     matches = syncer.sync()
     results = syncer.save_matches_to_db(matches)

--- a/match_data_fetcher.py
+++ b/match_data_fetcher.py
@@ -601,7 +601,7 @@ class MatchDataFetcher:
 
                     # Fallback: если после фильтрации 0 матчей, вернуть топ-3 самых свежих
                     if not h2h_matches and matches_before_date_filter:
-                        logger.warning("H2H фильтрация вернула 0 матчей, используем топ-3 из всех")
+                        logger.info("H2H фильтрация вернула 0 матчей, используем топ-3 из всех")
                         h2h_matches = sorted(
                             matches_before_date_filter,
                             key=lambda x: x['date'],

--- a/sync_matches.py
+++ b/sync_matches.py
@@ -668,7 +668,9 @@ def run_coverage_check(
     sleep_seconds: float = 1.2
 ) -> Dict[str, int]:
     """
-    Проверяет coverage для матчей с coverage_ok IS NULL.
+    Проверяет coverage для новых матчей (coverage_ok IS NULL)
+    и перепроверяет ранее скрытые (coverage_ok = 0) старше 3 часов
+    или без coverage_checked_at.
     Обновляет coverage_ok и coverage_checked_at для каждого матча.
     """
     from match_data_fetcher import MatchDataFetcher
@@ -689,12 +691,22 @@ def run_coverage_check(
     _ensure_coverage_columns(cursor)
     conn.commit()
 
+    recheck_cutoff = (
+        datetime.now() - timedelta(hours=3)
+    ).strftime('%Y-%m-%d %H:%M:%S')
     cursor.execute('''
         SELECT *
         FROM matches
         WHERE coverage_ok IS NULL
+           OR (
+                coverage_ok = 0
+                AND (
+                    coverage_checked_at IS NULL
+                    OR coverage_checked_at < ?
+                )
+           )
         ORDER BY match_date, match_time
-    ''')
+    ''', (recheck_cutoff,))
     matches = cursor.fetchall()
 
     if not matches:

--- a/tests/test_sync_matches.py
+++ b/tests/test_sync_matches.py
@@ -388,6 +388,97 @@ class TestCoverageCheck:
         finally:
             os.unlink(db_path)
 
+    @patch('match_data_fetcher.MatchDataFetcher.fetch_match_data')
+    @patch('analysis_formatter.build_table_data')
+    def test_coverage_check_rechecks_old_hidden_match(
+        self,
+        mock_build_table_data,
+        mock_fetch_match_data
+    ):
+        db_path = _create_test_db()
+        future_date = (datetime.now().date() + timedelta(days=1)).strftime('%Y-%m-%d')
+        stale_checked_at = (
+            datetime.now() - timedelta(hours=4)
+        ).strftime('%Y-%m-%d %H:%M:%S')
+        try:
+            match_id = _insert_match(
+                db_path,
+                api_event_id='cov-recheck-old-1',
+                match_date=future_date,
+                coverage_ok=0
+            )
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                'UPDATE matches SET coverage_checked_at = ? WHERE id = ?',
+                (stale_checked_at, match_id)
+            )
+            conn.commit()
+            conn.close()
+
+            mock_fetch_match_data.return_value = {}
+            mock_build_table_data.return_value = {
+                'raw_coverage_rows_count': 6,
+                'raw_missing_cells_count': 0,
+            }
+
+            results = run_coverage_check(db_path=db_path, sleep_seconds=0)
+
+            conn = sqlite3.connect(db_path)
+            row = conn.execute(
+                'SELECT coverage_ok, coverage_checked_at FROM matches WHERE id = ?',
+                (match_id,)
+            ).fetchone()
+            conn.close()
+
+            assert results['checked'] == 1
+            assert results['ok'] == 1
+            assert results['hidden'] == 0
+            assert row[0] == 1
+            assert row[1] is not None
+            assert row[1] != stale_checked_at
+        finally:
+            os.unlink(db_path)
+
+    @patch('match_data_fetcher.MatchDataFetcher.fetch_match_data')
+    @patch('analysis_formatter.build_table_data')
+    def test_coverage_check_rechecks_hidden_match_without_timestamp(
+        self,
+        mock_build_table_data,
+        mock_fetch_match_data
+    ):
+        db_path = _create_test_db()
+        future_date = (datetime.now().date() + timedelta(days=1)).strftime('%Y-%m-%d')
+        try:
+            match_id = _insert_match(
+                db_path,
+                api_event_id='cov-recheck-null-1',
+                match_date=future_date,
+                coverage_ok=0
+            )
+
+            mock_fetch_match_data.return_value = {}
+            mock_build_table_data.return_value = {
+                'raw_coverage_rows_count': 6,
+                'raw_missing_cells_count': 0,
+            }
+
+            results = run_coverage_check(db_path=db_path, sleep_seconds=0)
+
+            conn = sqlite3.connect(db_path)
+            row = conn.execute(
+                'SELECT coverage_ok, coverage_checked_at FROM matches WHERE id = ?',
+                (match_id,)
+            ).fetchone()
+            conn.close()
+
+            assert results['checked'] == 1
+            assert results['ok'] == 1
+            assert results['hidden'] == 0
+            assert row[0] == 1
+            assert row[1] is not None
+        finally:
+            os.unlink(db_path)
+
 
 class TestStorefrontCoverageFilter:
     """Тесты фильтрации витрины по coverage_ok."""


### PR DESCRIPTION
## Что сделано
- включил мягкий фильтр качества в scheduled sync через min_coverage_rows=6
- вернул перепроверку скрытых матчей по coverage с безопасным условием для coverage_checked_at IS NULL
- добавил регрессионные тесты на recheck скрытых матчей
- понизил шумный H2H fallback лог с WARNING до INFO

## Проверка
- pytest -q
- pytest -q tests/test_sync_matches.py