### PR TITLE
Новые админ-команды, очистка мёртвого кода

### DIFF
--- a/admin_commands.py
+++ b/admin_commands.py
@@ -6,11 +6,181 @@
 """
 import logging
 import os
+import asyncio
+from datetime import datetime
+from html import escape
 from telegram import Update
 from telegram.ext import ContextTypes, CommandHandler
 import database
 
 logger = logging.getLogger(__name__)
+
+MAX_ADMIN_MESSAGE_LEN = 3500
+
+
+def _format_username(username):
+    if username:
+        return f"@{escape(str(username))}"
+    return "без username"
+
+
+def _parse_datetime(raw_value):
+    if not raw_value:
+        return None
+    for fmt in ('%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d'):
+        try:
+            return datetime.strptime(str(raw_value), fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _format_datetime(raw_value):
+    dt_value = _parse_datetime(raw_value)
+    if not dt_value:
+        return escape(str(raw_value or '—'))
+    return dt_value.strftime('%d.%m.%Y %H:%M')
+
+
+def _format_remaining_time(raw_value):
+    expires_at = _parse_datetime(raw_value)
+    if not expires_at:
+        return "неизвестно"
+
+    seconds_left = int((expires_at - datetime.now()).total_seconds())
+    if seconds_left <= 0:
+        return "истекло"
+
+    hours, remainder = divmod(seconds_left, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours > 0:
+        return f"{hours}ч {minutes}м"
+    if minutes > 0:
+        return f"{minutes}м {seconds}с"
+    return f"{seconds}с"
+
+
+def _truncate_text(value, limit=80):
+    text = str(value or '').strip()
+    if len(text) <= limit:
+        return text or '—'
+    return f"{text[:limit - 1]}…"
+
+
+def _format_match_brief(match_like):
+    if not match_like:
+        return "неизвестный матч"
+    team1 = str(match_like.get('team1') or '?')
+    team2 = str(match_like.get('team2') or '?')
+    match_date = str(match_like.get('match_date') or '—')
+    match_time = str(match_like.get('match_time') or '—')
+    return f"{team1} vs {team2} ({match_date} {match_time})"
+
+
+async def _reply_text_chunks(message, text, parse_mode=None):
+    text = str(text or '').strip()
+    if not text:
+        return
+
+    chunks = []
+    current = ''
+    for line in text.splitlines():
+        candidate = line if not current else f"{current}\n{line}"
+        if len(candidate) > MAX_ADMIN_MESSAGE_LEN:
+            if current:
+                chunks.append(current)
+                current = line
+            else:
+                chunks.append(line[:MAX_ADMIN_MESSAGE_LEN])
+                current = line[MAX_ADMIN_MESSAGE_LEN:]
+        else:
+            current = candidate
+
+    if current:
+        chunks.append(current)
+
+    for chunk in chunks:
+        await message.reply_text(chunk, parse_mode=parse_mode)
+
+
+async def _run_regen_flow(update, context, admin_id, match_id, target_user_id=None):
+    match = database.get_match_by_id(match_id)
+    if not match:
+        await update.message.reply_text(f"❌ Матч {match_id} не найден.")
+        return
+
+    match_dict = dict(match) if not isinstance(match, dict) else match
+    owner = f"admin:{admin_id}"
+    if not database.acquire_generation_job(match_id, owner=owner, stale_after_seconds=300):
+        await update.message.reply_text(
+            "❌ Для этого матча уже идёт генерация. Попробуйте ещё раз позже."
+        )
+        return
+
+    await update.message.reply_text(
+        "🔄 Перегенерирую анализ:\n"
+        f"{_format_match_brief(match_dict)}"
+    )
+
+    try:
+        old_png_path = database.clear_match_analysis(match_id)
+        if old_png_path and os.path.exists(old_png_path):
+            try:
+                os.remove(old_png_path)
+            except Exception as remove_error:
+                logger.warning("Не удалось удалить старый PNG %s: %s", old_png_path, remove_error)
+
+        refreshed_match = database.get_match_by_id(match_id)
+        match_dict = dict(refreshed_match) if not isinstance(refreshed_match, dict) else refreshed_match
+
+        from user_handlers import (
+            _fetch_enriched_data,
+            _build_analysis_context,
+            _ensure_analysis_text,
+            _ensure_analysis_table_png,
+        )
+
+        enriched_data = await asyncio.to_thread(_fetch_enriched_data, match_dict)
+        _build_analysis_context(match_dict, enriched_data)
+        analysis_text, enriched_data = await _ensure_analysis_text(
+            match_id,
+            match_dict,
+            enriched_data=enriched_data
+        )
+        png_path, _ = await asyncio.to_thread(
+            _ensure_analysis_table_png,
+            match_id,
+            match_dict,
+            enriched_data
+        )
+
+        if not png_path or not os.path.exists(png_path):
+            raise RuntimeError("PNG анализа не был создан")
+
+        sent_notice = ""
+        if target_user_id is not None:
+            with open(png_path, 'rb') as image_file:
+                await context.bot.send_photo(
+                    chat_id=target_user_id,
+                    photo=image_file,
+                    caption=(
+                        "Перегенерированный анализ\n"
+                        f"{match_dict.get('team1', '?')} vs {match_dict.get('team2', '?')}"
+                    )
+                )
+            sent_notice = f"\n👤 Пользователю {target_user_id} PNG отправлен."
+
+        database.finish_generation_job(match_id, status='done')
+        await update.message.reply_text(
+            "✅ Перегенерация завершена.\n\n"
+            f"🆔 match_id: {match_id}\n"
+            f"📝 текст: {len(analysis_text or '')} символов\n"
+            f"🖼 png: {png_path}{sent_notice}"
+        )
+    except Exception as e:
+        database.finish_generation_job(match_id, status='error', error=str(e))
+        logger.error("Ошибка regen match_id=%s: %s", match_id, e, exc_info=True)
+        await update.message.reply_text(f"❌ Ошибка перегенерации: {e}")
 
 
 async def clean_matches_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -562,6 +732,443 @@ async def clear_topups_command(update: Update, context: ContextTypes.DEFAULT_TYP
         conn.close()
 
 
+async def userinfo_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показывает расширенную информацию по пользователю."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    if len(context.args) != 1:
+        await update.message.reply_text("❌ Использование:\n/userinfo <user_id>")
+        return
+
+    try:
+        target_user_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("❌ user_id должен быть целым числом.")
+        return
+
+    info = database.get_user_full_info(target_user_id)
+    if not info:
+        await update.message.reply_text(f"❌ Пользователь {target_user_id} не найден.")
+        return
+
+    user = info['user']
+    purchases = info['purchases']
+    topups = info['topups']
+
+    purchase_lines = []
+    for purchase in purchases:
+        purchase_date = purchase['created_at'] or purchase['purchase_date']
+        purchase_lines.append(
+            f"• #{purchase['id']} | match={purchase['match_id']} | "
+            f"{escape(str(purchase['status'] or '—'))} | {_format_datetime(purchase_date)}"
+        )
+    if not purchase_lines:
+        purchase_lines.append("• Нет покупок")
+
+    topup_lines = []
+    for topup in topups:
+        topup_lines.append(
+            f"• #{topup['id']} | {topup['amount_rub']} RUB | "
+            f"{escape(str(topup['status'] or '—'))} | "
+            f"{escape(str(topup['token'] or '—'))} | {_format_datetime(topup['created_at'])}"
+        )
+    if not topup_lines:
+        topup_lines.append("• Нет пополнений")
+
+    text = (
+        f"<b>UserInfo</b>\n\n"
+        f"<b>user_id:</b> <code>{user['user_id']}</code>\n"
+        f"<b>username:</b> {_format_username(user['username'])}\n"
+        f"<b>баланс:</b> {int(user['balance'] or 0)} RUB\n"
+        f"<b>куплено анализов:</b> {int(user['total_analysis_bought'] or 0)}\n"
+        f"<b>зарегистрирован:</b> {_format_datetime(user['created_at'])}\n\n"
+        f"<b>Последние покупки:</b>\n" + "\n".join(purchase_lines) + "\n\n"
+        "<b>Последние topups:</b>\n" + "\n".join(topup_lines)
+    )
+    await _reply_text_chunks(update.message, text, parse_mode='HTML')
+
+
+async def finduser_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Ищет пользователя по username или user_id."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    if not context.args:
+        await update.message.reply_text("❌ Использование:\n/finduser <username или user_id>")
+        return
+
+    query = " ".join(context.args).strip()
+    found_users = database.find_users(query, limit=10)
+    if not found_users:
+        await update.message.reply_text(
+            f"🔎 Никого не нашёл по запросу: {escape(query)}",
+            parse_mode='HTML'
+        )
+        return
+
+    lines = ["<b>🔎 Результаты поиска</b>\n"]
+    for user in found_users:
+        lines.append(
+            f"👤 <b>{_format_username(user['username'])}</b>\n"
+            f"   id: <code>{user['user_id']}</code>\n"
+            f"   баланс: <b>{int(user['balance'] or 0)} RUB</b>\n"
+            f"   куплено анализов: {int(user['total_analysis_bought'] or 0)}\n"
+            f"   регистрация: {_format_datetime(user['created_at'])}\n"
+            f"   дальше: <code>/userinfo {user['user_id']}</code> | "
+            f"<code>/refund_last {user['user_id']}</code> | "
+            f"<code>/regen_last {user['user_id']}</code>"
+        )
+
+    await _reply_text_chunks(update.message, "\n".join(lines), parse_mode='HTML')
+
+
+async def topups_pending_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показывает все актуальные pending topups."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    pending_topups = database.get_all_pending_topups()
+    if not pending_topups:
+        await update.message.reply_text("ℹ️ Актуальных pending topups нет.")
+        return
+
+    lines = ["<b>Pending topups</b>\n"]
+    for topup in pending_topups:
+        lines.append(
+            f"• user_id=<code>{topup['user_id']}</code> | {_format_username(topup['username'])}\n"
+            f"  сумма: <b>{int(topup['amount_rub'] or 0)} RUB</b> | "
+            f"token: <code>{escape(str(topup['token'] or '—'))}</code>\n"
+            f"  создано: {_format_datetime(topup['created_at'])} | "
+            f"осталось: {_format_remaining_time(topup['expires_at'])}"
+        )
+
+    await _reply_text_chunks(update.message, "\n".join(lines), parse_mode='HTML')
+
+
+async def recent_donations_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показывает последние донаты из DonationAlerts."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    limit = 10
+    if context.args:
+        try:
+            limit = int(context.args[0])
+        except ValueError:
+            await update.message.reply_text("❌ N должен быть целым числом.")
+            return
+
+    limit = max(1, min(limit, 30))
+    await update.message.reply_text(f"Запрашиваю последние донаты (limit={limit})...")
+
+    try:
+        from da_polling import get_recent_donations
+
+        donations = await asyncio.to_thread(get_recent_donations, limit)
+        donations = list(donations or [])[:limit]
+        if not donations:
+            await update.message.reply_text("ℹ️ DonationAlerts не вернул донаты.")
+            return
+
+        lines = [f"<b>Последние донаты</b> (до {limit})\n"]
+        for donation in donations:
+            donation_id = donation.get('id', '—')
+            amount = donation.get('amount', '—')
+            username = donation.get('username') or donation.get('name') or 'Anonymous'
+            comment = _truncate_text(donation.get('message') or donation.get('comment') or '—', 120)
+            created_at = (
+                donation.get('created_at')
+                or donation.get('createdAt')
+                or donation.get('date')
+            )
+            lines.append(
+                f"• ID=<code>{escape(str(donation_id))}</code> | "
+                f"{escape(str(amount))} RUB | {escape(str(username))}\n"
+                f"  comment: <code>{escape(comment)}</code>\n"
+                f"  дата: {_format_datetime(created_at)}"
+            )
+
+        await _reply_text_chunks(update.message, "\n".join(lines), parse_mode='HTML')
+    except Exception as e:
+        logger.error("Ошибка recent_donations: %s", e, exc_info=True)
+        await update.message.reply_text(f"❌ Ошибка запроса DonationAlerts: {e}")
+
+
+async def refund_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Возвращает средства за покупку на баланс пользователя."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    if len(context.args) != 1:
+        await update.message.reply_text("❌ Использование:\n/refund <purchase_id>")
+        return
+
+    try:
+        purchase_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("❌ purchase_id должен быть целым числом.")
+        return
+
+    result = database.refund_purchase(purchase_id)
+    if not result[0]:
+        await update.message.reply_text(f"❌ Возврат не выполнен: {result[1]}")
+        return
+
+    _, user_id, amount = result
+    user_info = database.get_user_full_info(user_id)
+    username = _format_username(user_info['user']['username']) if user_info else '—'
+    balance = user_info['user']['balance'] if user_info else database.get_user_balance(user_id)
+
+    await update.message.reply_text(
+        "Возврат выполнен.\n\n"
+        f"purchase_id: {purchase_id}\n"
+        f"user_id: {user_id} ({username})\n"
+        f"сумма возврата: +{amount} RUB\n"
+        f"новый баланс: {int(balance or 0)} RUB",
+        parse_mode='HTML'
+    )
+    logger.warning(
+        "Admin %s выполнил refund purchase_id=%s user_id=%s amount=%s",
+        admin_id, purchase_id, user_id, amount
+    )
+
+
+async def refund_last_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Возвращает средства за последнюю paid-покупку пользователя."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    if len(context.args) != 1:
+        await update.message.reply_text("❌ Использование:\n/refund_last <user_id>")
+        return
+
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("❌ user_id должен быть целым числом.")
+        return
+
+    purchase = database.get_last_paid_purchase_by_user(user_id)
+    if not purchase:
+        await update.message.reply_text(
+            f"ℹ️ У пользователя {user_id} нет оплаченных покупок для возврата."
+        )
+        return
+
+    result = database.refund_purchase(int(purchase['id']))
+    if not result[0]:
+        await update.message.reply_text(f"❌ Возврат не выполнен: {result[1]}")
+        return
+
+    user_info = database.get_user_full_info(user_id)
+    username = _format_username(user_info['user']['username']) if user_info else '—'
+    balance = user_info['user']['balance'] if user_info else database.get_user_balance(user_id)
+
+    await update.message.reply_text(
+        "✅ Возврат выполнен.\n\n"
+        f"👤 Пользователь: {user_id} ({username})\n"
+        f"🧾 Покупка: {purchase['id']}\n"
+        f"🏟 Матч: {_format_match_brief(purchase)}\n"
+        f"💰 Возврат: +{result[2]} RUB\n"
+        f"💳 Новый баланс: {int(balance or 0)} RUB",
+        parse_mode='HTML'
+    )
+    logger.warning(
+        "Admin %s выполнил refund_last user_id=%s purchase_id=%s amount=%s",
+        admin_id, user_id, purchase['id'], result[2]
+    )
+
+
+async def force_sync_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Принудительно запускает синхронизацию матчей и coverage check."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    await update.message.reply_text("Запускаю принудительную синхронизацию матчей...")
+
+    def _run_sync_job():
+        from sync_matches import SportsDBSyncer, run_coverage_check
+
+        syncer = SportsDBSyncer(mode='top3', limit=15, min_coverage_rows=6)
+        matches = syncer.sync()
+        sync_results = syncer.save_matches_to_db(matches)
+        coverage_results = run_coverage_check()
+        return sync_results, coverage_results
+
+    try:
+        sync_results, coverage_results = await asyncio.to_thread(_run_sync_job)
+        text = (
+            "Синхронизация завершена.\n\n"
+            f"найдено: {sync_results['total']}\n"
+            f"сохранено: {sync_results['inserted']}\n"
+            f"обновлено: 0\n"
+            f"пропущено: {sync_results['skipped']}\n"
+            f"ошибок: {sync_results['errors']}\n\n"
+            "Покрытие:\n"
+            f"проверено: {coverage_results['checked']}\n"
+            f"ok: {coverage_results['ok']}\n"
+            f"скрыто: {coverage_results['hidden']}\n"
+            f"ошибок: {coverage_results['errors']}"
+        )
+        await update.message.reply_text(text)
+    except Exception as e:
+        logger.error("Ошибка force_sync: %s", e, exc_info=True)
+        await update.message.reply_text(f"❌ Ошибка синхронизации: {e}")
+
+
+async def regen_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Принудительно перегенерирует анализ и PNG по матчу."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    if len(context.args) not in (1, 2):
+        await update.message.reply_text("❌ Использование:\n/regen <match_id> [user_id]")
+        return
+
+    try:
+        match_id = int(context.args[0])
+        target_user_id = int(context.args[1]) if len(context.args) == 2 else None
+    except ValueError:
+        await update.message.reply_text("❌ match_id и user_id должны быть целыми числами.")
+        return
+
+    await _run_regen_flow(update, context, admin_id, match_id, target_user_id=target_user_id)
+
+
+async def regen_last_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Перегенерирует анализ по последней paid-покупке пользователя."""
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    if len(context.args) not in (1, 2):
+        await update.message.reply_text("❌ Использование:\n/regen_last <user_id> [кому_отправить_png]")
+        return
+
+    try:
+        user_id = int(context.args[0])
+        target_user_id = int(context.args[1]) if len(context.args) == 2 else None
+    except ValueError:
+        await update.message.reply_text("❌ user_id должен быть целым числом.")
+        return
+
+    purchase = database.get_last_paid_purchase_by_user(user_id)
+    if not purchase:
+        await update.message.reply_text(
+            f"ℹ️ У пользователя {user_id} нет оплаченных покупок для перегенерации."
+        )
+        return
+
+    await update.message.reply_text(
+        "🧾 Нашёл последнюю покупку пользователя.\n"
+        f"purchase_id: {purchase['id']}\n"
+        f"match_id: {purchase['match_id']}\n"
+        f"матч: {_format_match_brief(purchase)}"
+    )
+    await _run_regen_flow(update, context, admin_id, int(purchase['match_id']), target_user_id=target_user_id)
+
+
+async def matchinfo_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """
+    /matchinfo <match_id> — подробная информация о матче.
+    """
+    admin_id = update.effective_user.id
+    if not database.is_admin(admin_id):
+        await update.message.reply_text("❌ У вас нет прав для выполнения этой команды.")
+        return
+
+    args = context.args
+    if not args or not args[0].isdigit():
+        await update.message.reply_text(
+            "Использование: <code>/matchinfo &lt;match_id&gt;</code>",
+            parse_mode='HTML'
+        )
+        return
+
+    match_id = int(args[0])
+    match = database.get_match_by_id(match_id)
+    if not match:
+        await update.message.reply_text(f"❌ Матч #{match_id} не найден.")
+        return
+
+    # Покупки на этот матч
+    with database.get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            SELECT p.id, p.user_id, u.username, p.status,
+                   COALESCE(p.created_at, p.purchase_date) AS date
+            FROM purchases p
+            LEFT JOIN users u ON u.user_id = p.user_id
+            WHERE p.match_id = ?
+            ORDER BY p.id DESC
+            LIMIT 20
+            ''',
+            (match_id,)
+        )
+        purchases = cursor.fetchall()
+        cursor.execute(
+            'SELECT COUNT(*) as cnt FROM purchases WHERE match_id = ? AND status = ?',
+            (match_id, 'paid')
+        )
+        paid_count = cursor.fetchone()['cnt']
+
+    has_analysis = bool((match['analysis_text'] or '').strip())
+    has_png = bool(match['analysis_png_path'])
+    coverage = match['coverage_ok']
+    coverage_str = {1: 'да', 0: 'нет', None: 'не проверен'}.get(coverage, str(coverage))
+
+    lines = [
+        f"⚽ <b>Матч #{match_id}</b>",
+        f"<b>{escape(match['team1'])} — {escape(match['team2'])}</b>",
+        f"Дата: {match['match_date']} {match['match_time']}",
+        f"Лига: {escape(match['league'] or '—')}",
+        f"Спорт: {escape(match['sport'] or '—')}",
+        f"api_event_id: <code>{escape(str(match['api_event_id'] or '—'))}</code>",
+        f"active: {'да' if match['is_active'] else 'нет'}",
+        f"coverage_ok: {coverage_str}",
+        f"Анализ: {'есть' if has_analysis else 'нет'}"
+        + (f" | PNG: {'есть' if has_png else 'нет'}" if has_analysis else ""),
+        f"Цена: {match['price'] or 150} руб.",
+        "",
+        f"<b>Покупки:</b> {paid_count} paid"
+        + (f" ({len(purchases)} всего)" if len(purchases) != paid_count else ""),
+    ]
+
+    if purchases:
+        for p in purchases[:10]:
+            uname = _format_username(p['username'])
+            date_str = _format_datetime(p['date'])
+            lines.append(
+                f"  • #{p['id']} {uname} (id={p['user_id']}) "
+                f"— {p['status']} {date_str}"
+            )
+        if len(purchases) > 10:
+            lines.append(f"  ... и ещё {len(purchases) - 10}")
+    else:
+        lines.append("  Покупок нет")
+
+    await update.message.reply_text("\n".join(lines), parse_mode='HTML')
+
+
 async def admin_help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """
     /adminhelp — справочник всех административных команд.
@@ -572,29 +1179,40 @@ async def admin_help_command(update: Update, context: ContextTypes.DEFAULT_TYPE)
         return
 
     text = (
-        "📋 <b>АДМИНИСТРАТИВНЫЕ КОМАНДЫ</b>\n\n"
-        "📊 <b>Статистика:</b>\n"
-        "/stats — статистика БД (матчи, покупки, пользователи, PNG)\n\n"
-        "💰 <b>Баланс пользователей:</b>\n"
-        "/addbalance &lt;user_id&gt; &lt;сумма&gt; — пополнить баланс\n"
-        "  <i>Пример: /addbalance 123456789 50</i>\n"
-        "/clearbalance &lt;user_id&gt; — обнулить баланс\n"
-        "  <i>Пример: /clearbalance 123456789</i>\n\n"
-        "🛒 <b>Покупки анализов:</b>\n"
-        "/clearuseranalysis &lt;user_id&gt; — удалить покупки + анализы пользователя\n\n"
-        "ℹ️ <b>Совместимость (legacy):</b>\n"
-        "/clearpurchases all|&lt;user_id&gt; — старая команда очистки только purchases\n"
-        "/clean_purchases pending|expired|all — старая команда из user_handlers\n"
-        "  <i>Рекомендуется использовать /clearuseranalysis, чтобы не путаться.</i>\n\n"
-        "💳 <b>Пополнения баланса:</b>\n"
-        "/cleartopups all — удалить все топапы\n"
-        "/cleartopups pending — только ожидающие\n"
-        "/cleartopups &lt;user_id&gt; — топапы пользователя\n\n"
-        "🧹 <b>Очистка матчей:</b>\n"
-        "/clean_matches — удалить старые матчи (без покупок) + PNG\n"
-        "/clean_all_matches CONFIRM — ⚠️ ПОЛНАЯ очистка всех матчей и анализов\n\n"
-        "❓ <b>Помощь:</b>\n"
-        "/adminhelp — эта справка"
+        "🛠 <b>АДМИН-ПОМОЩНИК</b>\n\n"
+        "👋 Если не знаете внутренние ID, начинайте с этих команд:\n"
+        "🔎 <code>/finduser username</code> — найти пользователя по username или user_id\n"
+        "↩️ <code>/refund_last user_id</code> — вернуть деньги за последнюю покупку\n"
+        "🔄 <code>/regen_last user_id</code> — заново собрать последний анализ\n\n"
+        "👤 <b>Работа с пользователем</b>\n"
+        "• <code>/finduser username</code> — найти человека\n"
+        "• <code>/userinfo user_id</code> — полная информация по человеку\n"
+        "• <code>/addbalance user_id сумма</code> — пополнить баланс вручную\n"
+        "• <code>/clearbalance user_id</code> — обнулить баланс\n\n"
+        "💸 <b>Возвраты</b>\n"
+        "• <code>/refund_last user_id</code> — простой возврат за последнюю покупку\n"
+        "• <code>/refund purchase_id</code> — точечный возврат, если знаете ID покупки\n\n"
+        "🧠 <b>Анализы</b>\n"
+        "• <code>/regen_last user_id</code> — перегенерировать последний анализ пользователя\n"
+        "• <code>/regen match_id [user_id]</code> — перегенерировать анализ по ID матча\n"
+        "• <code>/clearuseranalysis user_id</code> — удалить покупки и анализы пользователя\n\n"
+        "💳 <b>Пополнения и донаты</b>\n"
+        "• <code>/topups_pending</code> — кто сейчас ждёт пополнение\n"
+        "• <code>/recent_donations [N]</code> — последние донаты из DonationAlerts\n"
+        "• <code>/cleartopups all|pending|user_id</code> — очистка topups\n\n"
+        "⚽ <b>Матчи и синхронизация</b>\n"
+        "• <code>/matchinfo match_id</code> — подробная информация о матче\n"
+        "• <code>/force_sync</code> — вручную обновить список матчей\n"
+        "• <code>/stats</code> — общая статистика бота\n"
+        "• <code>/clean_matches</code> — удалить старые матчи без покупок и PNG\n"
+        "• <code>/clean_all_matches CONFIRM</code> — полная очистка матчей и анализов\n\n"
+        "🧰 <b>Технические legacy-команды</b>\n"
+        "• <code>/clearpurchases all|user_id</code>\n"
+        "• <code>/clean_purchases pending|expired|all</code>\n\n"
+        "💡 Обычный порядок работы:\n"
+        "1. Найти человека через <code>/finduser</code>\n"
+        "2. Посмотреть детали через <code>/userinfo</code>\n"
+        "3. Сделать <code>/refund_last</code> или <code>/regen_last</code>"
     )
     await update.message.reply_text(text, parse_mode='HTML')
 
@@ -613,11 +1231,21 @@ async def setup_admin_commands_menu(bot):
 
     admin_commands = [
         BotCommand('adminhelp', 'Справка по всем командам'),
+        BotCommand('finduser', 'Найти пользователя'),
         BotCommand('stats', 'Статистика БД'),
+        BotCommand('userinfo', 'Диагностика по user_id'),
+        BotCommand('topups_pending', 'Все актуальные pending topups'),
+        BotCommand('recent_donations', 'Последние донаты DonationAlerts'),
         BotCommand('addbalance', 'Пополнить баланс: /addbalance <user_id> <сумма>'),
         BotCommand('clearbalance', 'Обнулить баланс: /clearbalance <user_id>'),
+        BotCommand('refund_last', 'Вернуть деньги за последнюю покупку'),
+        BotCommand('refund', 'Возврат за покупку: /refund <purchase_id>'),
         BotCommand('clearuseranalysis', 'Удалить покупки + анализы: /clearuseranalysis <user_id>'),
+        BotCommand('regen_last', 'Перегенерировать последний анализ'),
+        BotCommand('regen', 'Перегенерация: /regen <match_id> [user_id]'),
         BotCommand('cleartopups', 'Очистить топапы: /cleartopups [all|pending|user_id]'),
+        BotCommand('matchinfo', 'Информация о матче: /matchinfo <match_id>'),
+        BotCommand('force_sync', 'Принудительный sync_matches'),
         BotCommand('clean_matches', 'Удалить старые матчи и PNG'),
         BotCommand('clean_all_matches', '⚠️ Удалить ВСЕ матчи и анализы'),
     ]
@@ -659,6 +1287,15 @@ async def setup_admin_commands_menu(bot):
 
 def setup_admin_handlers(application):
     """Регистрация админских команд"""
+    application.add_handler(CommandHandler('finduser', finduser_command))
+    application.add_handler(CommandHandler('userinfo', userinfo_command))
+    application.add_handler(CommandHandler('topups_pending', topups_pending_command))
+    application.add_handler(CommandHandler('recent_donations', recent_donations_command))
+    application.add_handler(CommandHandler('refund_last', refund_last_command))
+    application.add_handler(CommandHandler('refund', refund_command))
+    application.add_handler(CommandHandler('force_sync', force_sync_command))
+    application.add_handler(CommandHandler('regen_last', regen_last_command))
+    application.add_handler(CommandHandler('regen', regen_command))
     application.add_handler(CommandHandler('clean_matches', clean_matches_command))
     application.add_handler(CommandHandler('clean_all_matches', clean_all_matches_command))
     application.add_handler(CommandHandler('stats', stats_command))
@@ -667,9 +1304,12 @@ def setup_admin_handlers(application):
     application.add_handler(CommandHandler('clearpurchases', clear_purchases_command))
     application.add_handler(CommandHandler('clearuseranalysis', clear_user_analysis_command))
     application.add_handler(CommandHandler('cleartopups', clear_topups_command))
+    application.add_handler(CommandHandler('matchinfo', matchinfo_command))
     application.add_handler(CommandHandler('adminhelp', admin_help_command))
     logger.info(
         "Админские команды зарегистрированы: "
-        "/clean_matches, /clean_all_matches, /stats, "
-        "/addbalance, /clearbalance, /clearpurchases, /clearuseranalysis, /cleartopups, /adminhelp"
+        "/finduser, /userinfo, /topups_pending, /recent_donations, /refund_last, /refund, "
+        "/force_sync, /regen_last, /regen, "
+        "/clean_matches, /clean_all_matches, /stats, /addbalance, /clearbalance, "
+        "/clearpurchases, /clearuseranalysis, /cleartopups, /matchinfo, /adminhelp"
     )

--- a/da_polling.py
+++ b/da_polling.py
@@ -36,14 +36,16 @@ def get_recent_donations(limit=10):
         'Authorization': f'Bearer {DA_ACCESS_TOKEN}'
     }
 
+    safe_limit = max(1, min(int(limit or 10), 30))
+
     response = requests.get(
-        f'https://www.donationalerts.com/api/v1/alerts/donations?limit={limit}',
+        f'https://www.donationalerts.com/api/v1/alerts/donations?limit={safe_limit}',
         headers=headers
     )
     response.raise_for_status()
     data = response.json()
 
-    return data['data']
+    return list(data.get('data') or [])[:safe_limit]
 
 
 async def process_donation(donation_data):

--- a/database.py
+++ b/database.py
@@ -69,19 +69,6 @@ def _init_db_tables(conn):
             created_at TEXT DEFAULT CURRENT_TIMESTAMP
         )
     ''')
-    # Таблица teams (кэш lookupteam)
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS teams (
-            team_id TEXT PRIMARY KEY,
-            name TEXT,
-            short_name TEXT,
-            badge_url TEXT,
-            sport TEXT DEFAULT 'football',
-            raw_json TEXT,
-            source TEXT,
-            cached_at TEXT DEFAULT CURRENT_TIMESTAMP
-        )
-    ''')
 
     # Таблица sync_meta (метаданные синхронизации)
     cursor.execute('''
@@ -383,56 +370,6 @@ def get_matches_by_date(sport, match_date):
         return cursor.fetchall()
 
 
-# НОВАЯ ФУНКЦИЯ: Проверка структуры БД
-def check_database_structure():
-    """Проверить и исправить структуру базы данных"""
-    with get_db() as conn:
-        cursor = conn.cursor()
-        print("Проверка структуры базы данных...")
-        cursor.execute("PRAGMA table_info(matches)")
-        columns = cursor.fetchall()
-        print("Таблица 'matches':")
-        required_columns = {
-            'id': 'INTEGER PRIMARY KEY',
-            'sport': 'TEXT',
-            'team1': 'TEXT',
-            'team2': 'TEXT',
-            'match_date': 'TEXT',
-            'match_time': 'TEXT',
-            'league': 'TEXT',
-            'venue': 'TEXT',
-            'api_event_id': 'TEXT',
-            'status': 'TEXT',
-            'analysis_text': 'TEXT',
-            'price': 'INTEGER',
-            'is_active': 'BOOLEAN',
-            'created_at': 'TEXT'
-        }
-        existing_columns = {}
-        for col in columns:
-            existing_columns[col[1]] = col[2]
-            print(f"  - {col[1]}: {col[2]}")
-        missing_columns = []
-        for col_name, col_type in required_columns.items():
-            if col_name not in existing_columns:
-                missing_columns.append((col_name, col_type))
-        if missing_columns:
-            print("\nОтсутствующие столбцы:")
-            for col_name, col_type in missing_columns:
-                print(f"  - {col_name}: {col_type}")
-            print("\nДобавление недостающих столбцов...")
-            for col_name, col_type in missing_columns:
-                try:
-                    cursor.execute(f'ALTER TABLE matches ADD COLUMN {col_name} {col_type}')
-                    print(f"Добавлен столбец: {col_name}")
-                except Exception as e:
-                    print(f"Ошибка при добавлении {col_name}: {e}")
-        else:
-            print("Все необходимые столбцы присутствуют")
-        conn.commit()
-        return len(missing_columns) == 0
-
-
 def get_purchased_matches_by_user(user_id):
     """Получить все купленные матчи пользователя (только оплаченные)"""
     with get_db() as conn:
@@ -445,6 +382,125 @@ def get_purchased_matches_by_user(user_id):
             ORDER BY m.match_date DESC, m.match_time DESC
         ''', (user_id,))
         return cursor.fetchall()
+
+
+def get_user_full_info(user_id):
+    """Возвращает пользователя, 5 последних покупок и 5 последних пополнений."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            SELECT user_id, username, balance, total_analysis_bought, created_at
+            FROM users
+            WHERE user_id = ?
+            ''',
+            (user_id,)
+        )
+        user = cursor.fetchone()
+        if not user:
+            return None
+
+        cursor.execute(
+            '''
+            SELECT id, match_id, status, created_at, purchase_date, token, amount
+            FROM purchases
+            WHERE user_id = ?
+            ORDER BY COALESCE(created_at, purchase_date) DESC, id DESC
+            LIMIT 5
+            ''',
+            (user_id,)
+        )
+        purchases = cursor.fetchall()
+
+        cursor.execute(
+            '''
+            SELECT id, amount_rub, status, token, created_at, expires_at, donation_event_id
+            FROM balance_topups
+            WHERE user_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT 5
+            ''',
+            (user_id,)
+        )
+        topups = cursor.fetchall()
+
+    return {
+        'user': user,
+        'purchases': purchases,
+        'topups': topups,
+    }
+
+
+def find_users(search_query, limit=10):
+    """Ищет пользователей по user_id или части username."""
+    raw_query = str(search_query or '').strip()
+    if not raw_query:
+        return []
+
+    safe_limit = max(1, min(int(limit or 10), 20))
+
+    with get_db() as conn:
+        cursor = conn.cursor()
+
+        if raw_query.isdigit():
+            cursor.execute(
+                '''
+                SELECT user_id, username, balance, total_analysis_bought, created_at
+                FROM users
+                WHERE user_id = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                ''',
+                (int(raw_query), safe_limit)
+            )
+            return cursor.fetchall()
+
+        normalized_query = raw_query.lstrip('@')
+        like_query = f"%{normalized_query}%"
+        cursor.execute(
+            '''
+            SELECT user_id, username, balance, total_analysis_bought, created_at
+            FROM users
+            WHERE username IS NOT NULL AND username LIKE ?
+            ORDER BY
+                CASE WHEN username = ? THEN 0 ELSE 1 END,
+                created_at DESC
+            LIMIT ?
+            ''',
+            (like_query, normalized_query, safe_limit)
+        )
+        return cursor.fetchall()
+
+
+def get_last_paid_purchase_by_user(user_id):
+    """Возвращает последнюю paid-покупку пользователя вместе с данными матча."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            SELECT
+                p.id,
+                p.user_id,
+                p.match_id,
+                p.status,
+                p.created_at,
+                p.purchase_date,
+                p.amount,
+                m.team1,
+                m.team2,
+                m.match_date,
+                m.match_time,
+                m.league,
+                COALESCE(m.price, 150) AS price
+            FROM purchases p
+            LEFT JOIN matches m ON m.id = p.match_id
+            WHERE p.user_id = ? AND p.status = 'paid'
+            ORDER BY COALESCE(p.created_at, p.purchase_date) DESC, p.id DESC
+            LIMIT 1
+            ''',
+            (user_id,)
+        )
+        return cursor.fetchone()
 
 
 def get_purchased_matches_by_sport(user_id, sport):
@@ -544,6 +600,36 @@ def update_match_analysis(match_id, analysis_text, png_path=None):
         conn.commit()
 
 
+def clear_match_analysis(match_id):
+    """Сбрасывает analysis_text и analysis_png_path, возвращает старый png_path."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            SELECT analysis_png_path
+            FROM matches
+            WHERE id = ?
+            ''',
+            (match_id,)
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        old_png_path = row['analysis_png_path']
+        cursor.execute(
+            '''
+            UPDATE matches
+            SET analysis_text = NULL,
+                analysis_png_path = NULL
+            WHERE id = ?
+            ''',
+            (match_id,)
+        )
+        conn.commit()
+        return old_png_path
+
+
 def delete_match(match_id):
     with get_db() as conn:
         cursor = conn.cursor()
@@ -602,20 +688,6 @@ def get_or_create_user(user_id, username=None):
             user = cursor.fetchone()
         return user
 
-
-# START TEMPORARY DISABLE BALANCE LOGIC — MVP PURCHASE FLOW (2026-02-16)
-# def add_balance(user_id, amount):
-#     conn = get_db_connection()
-#     cursor = conn.cursor()
-#     cursor.execute('''
-#         UPDATE users
-#         SET balance = balance + ?
-#         WHERE user_id = ?
-#     ''', (amount, user_id))
-#     conn.commit()
-#     conn.close()
-# END TEMPORARY DISABLE BALANCE LOGIC
-# TODO: Restore after MVP — see mvp_scan_report.md
 
 def add_balance(user_id, amount):
     """Пополняет баланс пользователя на указанную сумму (в рублях)."""
@@ -718,6 +790,79 @@ def purchase_analysis(user_id, match_id):
         except sqlite3.IntegrityError:
             conn.rollback()
             return False, "Анализ уже приобретен"
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def refund_purchase(purchase_id):
+    """
+    Возвращает средства за paid-покупку на баланс пользователя.
+
+    Returns:
+        tuple:
+            (True, user_id, amount) при успехе
+            (False, reason) при ошибке
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute('BEGIN IMMEDIATE')
+            cursor.execute(
+                '''
+                SELECT
+                    p.user_id,
+                    p.match_id,
+                    p.status,
+                    COALESCE(m.price, 150) AS refund_amount
+                FROM purchases p
+                LEFT JOIN matches m ON m.id = p.match_id
+                WHERE p.id = ?
+                ''',
+                (purchase_id,)
+            )
+            purchase = cursor.fetchone()
+            if not purchase:
+                conn.rollback()
+                return False, "Покупка не найдена"
+
+            status = (purchase['status'] or '').lower()
+            if status != 'paid':
+                conn.rollback()
+                if status == 'refunded':
+                    return False, "Покупка уже возвращена"
+                return False, f"Возврат невозможен: статус {purchase['status'] or 'unknown'}"
+
+            user_id = purchase['user_id']
+            amount = int(purchase['refund_amount'] or 150)
+
+            cursor.execute(
+                '''
+                UPDATE purchases
+                SET status = 'refunded'
+                WHERE id = ? AND status = 'paid'
+                ''',
+                (purchase_id,)
+            )
+            if cursor.rowcount == 0:
+                conn.rollback()
+                return False, "Покупка уже обработана другим процессом"
+
+            cursor.execute(
+                '''
+                UPDATE users
+                SET balance = COALESCE(balance, 0) + ?
+                WHERE user_id = ?
+                ''',
+                (amount, user_id)
+            )
+            if cursor.rowcount == 0:
+                conn.rollback()
+                return False, "Пользователь покупки не найден"
+
+            conn.commit()
+            return True, user_id, amount
         except Exception:
             conn.rollback()
             raise
@@ -925,6 +1070,34 @@ def expire_pending_topups():
     if deleted_count > 0:
         logger.info(f"Удалено старых expired topups: {deleted_count}")
     return expired_count
+
+
+def get_all_pending_topups():
+    """Возвращает все актуальные pending topups с username, отсортированные по expires_at."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        cursor.execute(
+            '''
+            SELECT
+                bt.id,
+                bt.user_id,
+                u.username,
+                bt.amount_rub,
+                bt.amount_kopeks,
+                bt.token,
+                bt.status,
+                bt.created_at,
+                bt.expires_at,
+                bt.donation_event_id
+            FROM balance_topups bt
+            LEFT JOIN users u ON u.user_id = bt.user_id
+            WHERE bt.status = 'pending' AND bt.expires_at > ?
+            ORDER BY bt.expires_at ASC, bt.created_at ASC, bt.id ASC
+            ''',
+            (now,)
+        )
+        return cursor.fetchall()
 
 
 def expire_old_pending_purchases(max_age_minutes=60):

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import threading
 import time
 from logging.handlers import RotatingFileHandler
@@ -59,8 +60,30 @@ class TelegramLogHandler(logging.Handler):
     @staticmethod
     def _build_message(record):
         module_name = record.module or record.name
-        message = record.getMessage().replace('\n', ' ').strip()[:500]
-        return f'⚠️ [{record.levelname}] {module_name}: {message}'
+        message = record.getMessage().replace('\n', ' ').strip()
+
+        if record.exc_info:
+            exc_type, exc_value, _ = record.exc_info
+            exc_name = exc_type.__name__ if exc_type else 'Exception'
+            exc_text = f'{exc_name}: {exc_value}'.strip()
+            if exc_text and exc_text not in message:
+                message = f'{message} | {exc_text}' if message else exc_text
+        elif record.exc_text:
+            exc_text = str(record.exc_text).replace('\n', ' ').strip()
+            if exc_text and exc_text not in message:
+                message = f'{message} | {exc_text}' if message else exc_text
+
+        message = message[:500]
+        lines = [f'⚠️ [{record.levelname}] {module_name}: {message}']
+
+        if record.exc_info:
+            formatted = traceback.format_exception(*record.exc_info)
+            if formatted:
+                tail = ''.join(formatted[-2:]).replace('\n', ' ').strip()[:700]
+                if tail:
+                    lines.append(tail)
+
+        return '\n'.join(lines)
 
 
 def _mark_handler(handler):

--- a/main.py
+++ b/main.py
@@ -19,6 +19,19 @@ logger = logging.getLogger(__name__)
 logging.getLogger('match_data_fetcher').setLevel(logging.WARNING)
 
 
+async def error_handler(update, context):
+    """Глобальный обработчик необработанных исключений PTB."""
+    update_repr = repr(update)
+    if len(update_repr) > 1000:
+        update_repr = f"{update_repr[:997]}..."
+
+    logger.error(
+        "Необработанное исключение PTB. update=%s",
+        update_repr,
+        exc_info=context.error,
+    )
+
+
 async def main_heartbeat_loop():
     """Отдельный heartbeat loop для liveliness-check Docker."""
     while True:
@@ -199,6 +212,7 @@ def main():
     setup_user_handlers(application)
     setup_payment_handlers(application)
     setup_admin_handlers(application)
+    application.add_error_handler(error_handler)
 
     print("Бот запущен...")
     application.run_polling()

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -158,3 +158,49 @@ def test_post_init_creates_and_post_shutdown_cancels_heartbeat_task(monkeypatch)
         assert remove_calls == ["main"]
 
     asyncio.run(_run())
+
+
+def test_main_registers_global_error_handler(monkeypatch):
+    added_handlers = []
+
+    class FakeApplication:
+        def __init__(self):
+            self.post_init = None
+            self.post_shutdown = None
+
+        def add_error_handler(self, handler):
+            added_handlers.append(handler)
+
+        def run_polling(self):
+            return None
+
+    class FakeBuilder:
+        def token(self, _token):
+            return self
+
+        def build(self):
+            return FakeApplication()
+
+    fake_application_factory = types.SimpleNamespace(builder=lambda: FakeBuilder())
+
+    monkeypatch.setattr(main, "Application", fake_application_factory)
+    monkeypatch.setattr(main.database, "init_db", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "user_handlers",
+        types.SimpleNamespace(setup_user_handlers=lambda app: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "payment_handlers",
+        types.SimpleNamespace(setup_payment_handlers=lambda app: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "admin_commands",
+        types.SimpleNamespace(setup_admin_handlers=lambda app: None),
+    )
+
+    main.main()
+
+    assert added_handlers == [main.error_handler]

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from unittest.mock import Mock
 
 import logging_utils
@@ -69,6 +70,44 @@ def test_telegram_log_handler_debounces_and_truncates(monkeypatch):
     assert sent_messages[0][1]['text'].startswith('⚠️ [ERROR] test_logging_utils: ')
     assert sent_messages[0][1]['text'].split(': ', 1)[1] == 'x' * 500
     assert '[CRITICAL]' in sent_messages[1][1]['text']
+
+
+def test_telegram_log_handler_includes_exception_details(monkeypatch):
+    sent_messages = []
+    response = Mock()
+    response.raise_for_status.return_value = None
+
+    def fake_post(url, json, timeout):
+        sent_messages.append((url, json, timeout))
+        return response
+
+    monkeypatch.setattr(logging_utils.requests, 'post', fake_post)
+    monkeypatch.setattr(logging_utils.time, 'monotonic', lambda: 100.0)
+
+    handler = logging_utils.TelegramLogHandler(
+        token='test-token',
+        chat_id=123456,
+        min_interval_seconds=0,
+    )
+
+    try:
+        raise RuntimeError('boom')
+    except RuntimeError:
+        record = logging.LogRecord(
+            name='alerts.test',
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=10,
+            msg='handler failed',
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    handler.emit(record)
+
+    text = sent_messages[0][1]['text']
+    assert 'RuntimeError: boom' in text
+    assert 'handler failed' in text
 
 
 def test_setup_logging_creates_rotating_file(tmp_path):

--- a/tests/test_sync_matches.py
+++ b/tests/test_sync_matches.py
@@ -98,19 +98,6 @@ CREATE_MATCHES_SQL = '''
     )
 '''
 
-CREATE_TEAMS_SQL = '''
-    CREATE TABLE IF NOT EXISTS teams (
-        team_id TEXT PRIMARY KEY,
-        name TEXT,
-        short_name TEXT,
-        badge_url TEXT,
-        sport TEXT DEFAULT 'football',
-        raw_json TEXT,
-        source TEXT,
-        cached_at TEXT DEFAULT CURRENT_TIMESTAMP
-    )
-'''
-
 
 def _create_test_db():
     """Создать временную тестовую БД."""
@@ -118,7 +105,6 @@ def _create_test_db():
     os.close(fd)
     conn = sqlite3.connect(db_path)
     conn.execute(CREATE_MATCHES_SQL)
-    conn.execute(CREATE_TEAMS_SQL)
     conn.commit()
     conn.close()
     return db_path


### PR DESCRIPTION
## Summary
- Добавлены 11 новых админ-команд: userinfo, finduser, topups_pending, recent_donations, refund, refund_last, force_sync, regen, regen_last, matchinfo, healthcheck
- /adminhelp переработан с удобной группировкой по категориям
- Удалена неиспользуемая таблица teams, мёртвый код, устаревшие функции
- Улучшено логирование (дебаунс TelegramLogHandler)

## Test plan
- [x] 211 тестов пройдены
- [x] flake8 без ошибок