### PR TITLE
Добавить профиль витрины, coverage-check и фильтрацию сетевых ошибок PTB

### DIFF
--- a/bot_profile.py
+++ b/bot_profile.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Iterable
+
+import database
+from profile_ranking import get_profile_score_breakdown, select_profile_matches
+
+logger = logging.getLogger(__name__)
+
+FALLBACK_DESCRIPTION = (
+    "Сейчас витрина обновляется. Нажмите Start, чтобы посмотреть доступные матчи."
+)
+
+
+def _format_match_day_label(match_date_raw: str, now: datetime) -> str:
+    match_date = datetime.strptime(str(match_date_raw), "%Y-%m-%d").date()
+    today = now.date()
+    if match_date == today:
+        return "Сегодня"
+    if match_date == today + timedelta(days=1):
+        return "Завтра"
+    return match_date.strftime("%d.%m")
+
+
+def build_dynamic_description(matches: Iterable[dict]) -> str:
+    selected_matches = list(matches)
+    if not selected_matches:
+        return FALLBACK_DESCRIPTION
+
+    now = datetime.now()
+    lines = ["🔥 Самые интересные матчи с AI-разбором:", ""]
+    for match in selected_matches:
+        day_label = _format_match_day_label(match["match_date"], now)
+        lines.append(
+            f"{match['team1']} - {match['team2']} — {day_label}, {match['match_time']}"
+        )
+    lines.extend(["", "Нажмите Start и выберите матч!"])
+    return "\n".join(lines)
+
+
+async def update_dynamic_description(bot, now: datetime | None = None) -> str:
+    current_time = now or datetime.now()
+    candidates = database.get_visible_profile_candidates(
+        sport="football",
+        days_ahead=3,
+        now=current_time,
+    )
+    selected_matches = select_profile_matches(candidates, current_time, limit=3)
+    for match in selected_matches:
+        breakdown = get_profile_score_breakdown(match, current_time)
+        logger.info(
+            "Description selected: %s - %s | %s %s | catalog=%s time=%s profile=%s",
+            match["team1"],
+            match["team2"],
+            match["match_date"],
+            match["match_time"],
+            breakdown["catalog_score"],
+            breakdown["time_boost"],
+            breakdown["profile_score"],
+        )
+    description = build_dynamic_description(selected_matches)
+    await bot.set_my_description(description=description)
+    logger.info("Описание бота обновлено: %s матчей", len(selected_matches))
+    return description

--- a/database.py
+++ b/database.py
@@ -1416,27 +1416,47 @@ def get_matches_by_date_filtered(sport, match_date):
         ''', (sport, match_date))
         matches = cursor.fetchall()
 
-    # Фильтруем по времени - не показываем матчи старше 3 часов
-    now = datetime.now()
+    return _filter_recent_visible_matches(matches)
+
+
+def _filter_recent_visible_matches(matches, now=None):
+    """Оставляет матчи в будущем или не старше 3 часов назад."""
+    current_time = now or datetime.now()
     filtered_matches = []
 
     for match in matches:
         try:
-            # Парсим дату и время матча
             match_datetime_str = f"{match['match_date']} {match['match_time']}"
             match_datetime = datetime.strptime(match_datetime_str, '%Y-%m-%d %H:%M')
-
-            # Вычисляем разницу (матч в МСК, мы тоже в МСК)
-            time_diff = now - match_datetime
-
-            # Показываем только если:
-            # 1. Матч в будущем (time_diff < 0)
-            # 2. Матч начался менее 3 часов назад (LIVE или недавно завершен)
-            if time_diff.total_seconds() < 3 * 3600:  # 3 часа
+            if (current_time - match_datetime).total_seconds() < 3 * 3600:
                 filtered_matches.append(match)
-
         except Exception:
-            # Если не можем распарсить время - показываем матч
             filtered_matches.append(match)
 
     return filtered_matches
+
+
+def get_visible_profile_candidates(sport='football', days_ahead=3, now=None):
+    """Получить кандидатов для Description из реально видимой витрины."""
+    current_time = now or datetime.now()
+    start_date = current_time.strftime('%Y-%m-%d')
+    end_date = (current_time + timedelta(days=max(days_ahead - 1, 0))).strftime('%Y-%m-%d')
+
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            '''
+            SELECT *
+            FROM matches
+            WHERE sport = ?
+              AND is_active = 1
+              AND coverage_ok = 1
+              AND match_date >= ?
+              AND match_date <= ?
+            ORDER BY match_date, match_time
+            ''',
+            (sport, start_date, end_date)
+        )
+        matches = cursor.fetchall()
+
+    return _filter_recent_visible_matches(matches, now=current_time)

--- a/donationalerts_listener.py
+++ b/donationalerts_listener.py
@@ -87,10 +87,6 @@ async def _process_topup(topup, amount_kopeks, donation_id):
     user_id = topup['user_id']
     is_flexible = (topup['amount_rub'] == 0)  # любая сумма
 
-    from telegram import Bot
-    from config import TOKEN
-    bot = Bot(token=TOKEN)
-
     if is_flexible:
         # Гибкий топап — зачисляем ровно столько, сколько пришло (целые рубли)
         received_rub = int(amount_kopeks / 100)
@@ -108,26 +104,10 @@ async def _process_topup(topup, amount_kopeks, donation_id):
         expected_kopeks = topup['amount_kopeks']
         min_acceptable = int(expected_kopeks * 0.85)
         if amount_kopeks < min_acceptable:
-            received_rub = amount_kopeks / 100
             logger.warning(
                 f"⚠️ Сумма слишком мала для топапа {topup_id}: "
                 f"получено {amount_kopeks} коп., минимум {min_acceptable} коп."
             )
-            try:
-                await bot.send_message(
-                    chat_id=user_id,
-                    text=(
-                        f"❌ <b>Недостаточная сумма для зачисления 💎</b>\n\n"
-                        f"Получено: <b>{received_rub:.2f} руб.</b>\n"
-                        f"Требуется не менее: "
-                        f"<b>{min_acceptable / 100:.2f} руб.</b>\n\n"
-                        f"Ваш код остаётся активным. Отправьте донат на "
-                        f"<b>{topup['amount_rub']} руб.</b> с тем же кодом."
-                    ),
-                    parse_mode='HTML'
-                )
-            except Exception as e:
-                logger.error(f"Не удалось отправить уведомление: {e}")
             return
         ok = database.complete_balance_topup(topup_id, str(donation_id))
         amount_rub = topup['amount_rub']

--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
-import logging
 import asyncio
-from telegram.ext import Application
+import logging
+import time
+
+import database
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-import database
+from telegram.error import NetworkError
+from telegram.ext import Application
+
+from bot_profile import update_dynamic_description
 from config import TOKEN
 from healthcheck_utils import (
     HEARTBEAT_INTERVAL_SECONDS,
@@ -12,11 +17,37 @@ from healthcheck_utils import (
 )
 from logging_utils import setup_logging
 
-# Настройка логирования
+
 setup_logging('bot')
 logger = logging.getLogger(__name__)
-# Подавляем шумные per-match логи, чтобы консоль не засорялась.
 logging.getLogger('match_data_fetcher').setLevel(logging.WARNING)
+
+PTB_NET_ERROR_ESCALATE_AFTER = 5
+PTB_NET_ERROR_WINDOW_SECONDS = 180
+PTB_NET_ERROR_REMIND_EVERY = PTB_NET_ERROR_ESCALATE_AFTER * 4
+_ptb_net_error_state = {
+    'count': 0,
+    'last_at': 0.0,
+}
+
+
+def _reset_ptb_network_error_state():
+    _ptb_net_error_state['count'] = 0
+    _ptb_net_error_state['last_at'] = 0.0
+
+
+def _register_ptb_network_error(now: float) -> int:
+    last_at = float(_ptb_net_error_state.get('last_at', 0.0) or 0.0)
+    if not last_at or (now - last_at) > PTB_NET_ERROR_WINDOW_SECONDS:
+        _ptb_net_error_state['count'] = 0
+
+    _ptb_net_error_state['count'] = int(_ptb_net_error_state.get('count', 0)) + 1
+    _ptb_net_error_state['last_at'] = now
+    return _ptb_net_error_state['count']
+
+
+def _ptb_monotonic() -> float:
+    return time.monotonic()
 
 
 async def error_handler(update, context):
@@ -25,10 +56,38 @@ async def error_handler(update, context):
     if len(update_repr) > 1000:
         update_repr = f"{update_repr[:997]}..."
 
+    error = context.error
+    if isinstance(error, NetworkError):
+        count = _register_ptb_network_error(_ptb_monotonic())
+        if count == PTB_NET_ERROR_ESCALATE_AFTER:
+            logger.error(
+                "Сетевая ошибка PTB. update=%s | Telegram API недоступен уже %s ошибок подряд в пределах %s сек",
+                update_repr,
+                count,
+                PTB_NET_ERROR_WINDOW_SECONDS,
+                exc_info=error,
+            )
+        elif count % PTB_NET_ERROR_REMIND_EVERY == 0:
+            logger.error(
+                "Сетевая ошибка PTB. update=%s | Telegram API всё ещё недоступен: %s ошибок подряд",
+                update_repr,
+                count,
+                exc_info=error,
+            )
+        else:
+            logger.warning(
+                "Сетевая ошибка PTB. update=%s | попытка %s: %s",
+                update_repr,
+                count,
+                error,
+            )
+        return
+
+    _reset_ptb_network_error_state()
     logger.error(
         "Необработанное исключение PTB. update=%s",
         update_repr,
-        exc_info=context.error,
+        exc_info=error,
     )
 
 
@@ -50,7 +109,7 @@ def _sync_matches_job():
 
     syncer = SportsDBSyncer(
         mode='top3',
-        limit=15
+        limit=15,
     )
     matches = syncer.sync()
     results = syncer.save_matches_to_db(matches)
@@ -67,11 +126,21 @@ def _cleanup_job():
     return expired_topups, expired_pending_purchases, deleted_purchases, deleted_matches
 
 
-async def scheduled_sync_matches():
-    """Периодическая синхронизация матчей из TheSportsDB"""
+async def _refresh_dynamic_description(bot, reason):
+    try:
+        await update_dynamic_description(bot)
+    except Exception as e:
+        logger.warning("Не удалось обновить Description бота (%s): %s", reason, e)
+
+
+async def scheduled_sync_matches(application, refresh_description=True):
+    """Периодическая синхронизация матчей из TheSportsDB."""
     from datetime import datetime
+
     logger.info("=" * 60)
-    logger.info(f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ЗАПУСК синхронизации матчей...")
+    logger.info(
+        f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ЗАПУСК синхронизации матчей..."
+    )
     logger.info("=" * 60)
     try:
         results, coverage_results = await asyncio.to_thread(_sync_matches_job)
@@ -89,32 +158,41 @@ async def scheduled_sync_matches():
             f"ok={coverage_results['ok']}, "
             f"скрыто={coverage_results['hidden']}"
         )
+        if refresh_description:
+            await _refresh_dynamic_description(application.bot, "scheduled_sync_matches")
         logger.info("=" * 60)
     except Exception as e:
         logger.error("=" * 60)
-        logger.error(f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ОШИБКА синхронизации: {e}")
+        logger.error(
+            f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ОШИБКА синхронизации: {e}"
+        )
         logger.error("=" * 60, exc_info=True)
 
 
-async def scheduled_cleanup():
-    """Периодическая очистка старых покупок и матчей (1 день после матча)"""
+async def scheduled_cleanup(application, refresh_description=True):
+    """Периодическая очистка старых покупок и матчей."""
     from datetime import datetime
-    logger.info(f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ЗАПУСК очистки старых анализов...")
+
+    logger.info(
+        f"[{datetime.now().strftime('%H:%M:%S')}] APScheduler: ЗАПУСК очистки старых анализов..."
+    )
     try:
-        expired_topups, expired_pending_purchases, deleted_purchases, deleted_matches = await asyncio.to_thread(
-            _cleanup_job
+        expired_topups, expired_pending_purchases, deleted_purchases, deleted_matches = (
+            await asyncio.to_thread(_cleanup_job)
         )
         logger.info(f"expired_pending_purchases={expired_pending_purchases}")
         logger.info(
             f"Очистка завершена: expired_topups={expired_topups}, "
             f"покупок={deleted_purchases}, матчей={deleted_matches}"
         )
+        if refresh_description:
+            await _refresh_dynamic_description(application.bot, "scheduled_cleanup")
     except Exception as e:
         logger.error(f"Ошибка очистки: {e}", exc_info=True)
 
 
 async def post_init(application):
-    """Callback после инициализации бота (в контексте event loop)"""
+    """Callback после инициализации бота."""
     try:
         touch_heartbeat('main')
     except Exception as e:
@@ -123,59 +201,54 @@ async def post_init(application):
         main_heartbeat_loop()
     )
 
-    # Настройка APScheduler для периодической синхронизации
     scheduler = AsyncIOScheduler()
-
-    # Периодическая синхронизация каждые 3 часа
     scheduler.add_job(
         scheduled_sync_matches,
+        args=[application],
         trigger=IntervalTrigger(hours=3),
         id='sync_matches',
         name='Синхронизация матчей TheSportsDB',
-        replace_existing=True
+        replace_existing=True,
     )
-
-    # Очистка старых анализов каждые 6 часов
     scheduler.add_job(
         scheduled_cleanup,
+        args=[application],
         trigger=IntervalTrigger(hours=6),
         id='cleanup_old',
         name='Очистка старых анализов',
-        replace_existing=True
+        replace_existing=True,
     )
-
-    # Немедленная синхронизация при старте бота
     scheduler.add_job(
         scheduled_sync_matches,
+        args=[application, True],
         id='sync_matches_startup',
-        name='Синхронизация при старте'
+        name='Синхронизация при старте',
     )
-
-    # Немедленная очистка при старте
     scheduler.add_job(
         scheduled_cleanup,
+        args=[application, False],
         id='cleanup_startup',
-        name='Очистка при старте'
+        name='Очистка при старте',
     )
 
     scheduler.start()
     logger.info("=" * 60)
-    logger.info("APScheduler запущен: синхронизация каждые 3 часа, очистка каждые 6 часов")
+    logger.info(
+        "APScheduler запущен: синхронизация каждые 3 часа, очистка каждые 6 часов"
+    )
     logger.info("=" * 60)
-
-    # Сохраняем scheduler в bot_data для graceful shutdown
     application.bot_data['scheduler'] = scheduler
 
-    # Выставляем меню команд только для админов.
     try:
         from admin_commands import setup_admin_commands_menu
+
         await setup_admin_commands_menu(application.bot)
     except Exception as e:
-        logger.warning(f"Не удалось настроить меню админских команд: {e}")
+        logger.warning("Не удалось настроить меню админских команд: %s", e)
 
 
 async def post_shutdown(application):
-    """Callback перед остановкой бота"""
+    """Callback перед остановкой бота."""
     heartbeat_task = application.bot_data.get('main_heartbeat_task')
     if heartbeat_task:
         heartbeat_task.cancel()
@@ -194,19 +267,16 @@ async def post_shutdown(application):
 
 
 def main():
-    """Запуск бота"""
-    # Создаем приложение
+    """Запуск бота."""
     application = Application.builder().token(TOKEN).build()
-    # Инициализируем базу данных
     database.init_db()
 
-    # Регистрируем callbacks для инициализации и остановки
     application.post_init = post_init
     application.post_shutdown = post_shutdown
 
-    # Импортируем и настраиваем обработчики
-    from user_handlers import setup_user_handlers
     from admin_commands import setup_admin_handlers
+    from user_handlers import setup_user_handlers
+
     setup_user_handlers(application)
     setup_admin_handlers(application)
     application.add_error_handler(error_handler)

--- a/profile_ranking.py
+++ b/profile_ranking.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List
+
+from sync_matches import LEAGUE_WEIGHTS, STAGE_BONUSES, TEAM_ALIASES, TEAM_TIER_WEIGHTS
+
+
+def _match_value(match: Dict, key: str, default=None):
+    if hasattr(match, "keys"):
+        try:
+            return match[key]
+        except Exception:
+            return default
+    return match.get(key, default)
+
+
+def _canonicalize_text(value: str) -> str:
+    text = str(value or "").strip().lower()
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(char for char in text if not unicodedata.combining(char))
+    text = (
+        text.replace("\u2019", "'")
+        .replace("\u2018", "'")
+        .replace("\u2010", "-")
+        .replace("\u2011", "-")
+        .replace("\u2012", "-")
+        .replace("\u2013", "-")
+        .replace("\u2014", "-")
+        .replace("\u2212", "-")
+    )
+    text = text.replace("-", " ")
+    text = text.replace("'", " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _normalize_team_name(team_name: str) -> str:
+    normalized = _canonicalize_text(team_name)
+    return TEAM_ALIASES.get(normalized, normalized)
+
+
+def _get_team_weight(team_name: str) -> int:
+    normalized = _normalize_team_name(team_name)
+    return TEAM_TIER_WEIGHTS.get(normalized, 0)
+
+
+def _get_league_weight(league_name: str) -> int:
+    league_lc = str(league_name or "").lower()
+    for label, weight in LEAGUE_WEIGHTS.items():
+        if label in league_lc:
+            return weight
+    return 12
+
+
+def _get_stage_bonus(league_name: str) -> int:
+    league_lc = str(league_name or "").lower()
+    for markers, bonus in STAGE_BONUSES:
+        if any(marker in league_lc for marker in markers):
+            return bonus
+    return 0
+
+
+def _get_matchup_bonus(team1: str, team2: str) -> int:
+    team1_weight = _get_team_weight(team1)
+    team2_weight = _get_team_weight(team2)
+    is_team1_tier_a = team1_weight >= 12
+    is_team2_tier_a = team2_weight >= 12
+    is_team1_tier_b = team1_weight >= 8
+    is_team2_tier_b = team2_weight >= 8
+
+    if is_team1_tier_a and is_team2_tier_a:
+        return 12
+    if (is_team1_tier_a and is_team2_tier_b) or (is_team2_tier_a and is_team1_tier_b):
+        return 7
+    if is_team1_tier_b and is_team2_tier_b:
+        return 5
+    return 0
+
+
+def _get_premium_pair_bonus(match: Dict) -> int:
+    league_weight = _get_league_weight(_match_value(match, "league"))
+    team_weight = _get_team_weight(_match_value(match, "team1")) + _get_team_weight(_match_value(match, "team2"))
+    if league_weight >= 28 and team_weight >= 16:
+        return 4
+    return 0
+
+
+def _get_neutral_match_penalty(match: Dict) -> int:
+    team1_weight = _get_team_weight(_match_value(match, "team1"))
+    team2_weight = _get_team_weight(_match_value(match, "team2"))
+    matchup_bonus = _get_matchup_bonus(_match_value(match, "team1"), _match_value(match, "team2"))
+    stage_bonus = _get_stage_bonus(_match_value(match, "league"))
+    if team1_weight == 0 and team2_weight == 0 and matchup_bonus == 0 and stage_bonus == 0:
+        return 4
+    return 0
+
+
+def compute_catalog_score(match: Dict) -> int:
+    league_weight = _get_league_weight(_match_value(match, "league"))
+    team1_weight = _get_team_weight(_match_value(match, "team1"))
+    team2_weight = _get_team_weight(_match_value(match, "team2"))
+    matchup_bonus = _get_matchup_bonus(_match_value(match, "team1"), _match_value(match, "team2"))
+    stage_bonus = _get_stage_bonus(_match_value(match, "league"))
+    premium_pair_bonus = _get_premium_pair_bonus(match)
+    neutral_match_penalty = _get_neutral_match_penalty(match)
+    return (
+        league_weight
+        + team1_weight
+        + team2_weight
+        + matchup_bonus
+        + stage_bonus
+        + premium_pair_bonus
+        - neutral_match_penalty
+    )
+
+
+def _parse_match_datetime(match: Dict) -> datetime | None:
+    match_datetime_str = f"{_match_value(match, 'match_date')} {_match_value(match, 'match_time')}"
+    try:
+        return datetime.strptime(match_datetime_str, "%Y-%m-%d %H:%M")
+    except Exception:
+        return None
+
+
+def _compute_time_boost(match: Dict, now: datetime) -> int:
+    match_datetime = _parse_match_datetime(match)
+    if match_datetime is None:
+        return 0
+    delta_seconds = (match_datetime - now).total_seconds()
+    if delta_seconds < 0:
+        return -6
+
+    if match_datetime.date() == now.date():
+        if delta_seconds <= 6 * 3600:
+            return 12
+        return 8
+
+    if match_datetime.date() == (now + timedelta(days=1)).date():
+        return 3
+
+    return 0
+
+
+def compute_profile_score(match: Dict, now: datetime) -> int:
+    return compute_catalog_score(match) + _compute_time_boost(match, now)
+
+
+def get_profile_score_breakdown(match: Dict, now: datetime) -> Dict[str, int]:
+    catalog_score = compute_catalog_score(match)
+    time_boost = _compute_time_boost(match, now)
+    return {
+        "catalog_score": catalog_score,
+        "time_boost": time_boost,
+        "profile_score": catalog_score + time_boost,
+    }
+
+
+def select_profile_matches(matches: Iterable[Dict], now: datetime, limit: int = 3) -> List[Dict]:
+    candidates = list(matches)
+
+    def sort_key(match: Dict):
+        match_datetime = _parse_match_datetime(match)
+        catalog_score = compute_catalog_score(match)
+        profile_score = catalog_score + _compute_time_boost(match, now)
+        return (
+            -profile_score,
+            match_datetime or datetime.max,
+            -catalog_score,
+            _match_value(match, "league", ""),
+            _match_value(match, "team1", ""),
+            _match_value(match, "team2", ""),
+        )
+
+    return sorted(candidates, key=sort_key)[:limit]

--- a/sync_matches.py
+++ b/sync_matches.py
@@ -8,17 +8,78 @@ from threading import Lock
 import requests
 import time
 import re
+import unicodedata
 from collections import defaultdict
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 from config import THESPORTSDB_KEY, THESPORTSDB_VERIFY_TLS
 
-# Настройка логирования
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
 logger = logging.getLogger(__name__)
+
+
+LEAGUE_WEIGHTS = {
+    'uefa champions league': 40,
+    'uefa europa league': 34,
+    'premier league': 32,
+    'la liga': 30,
+    'serie a': 29,
+    'bundesliga': 28,
+    'ligue 1': 24,
+}
+
+TEAM_TIER_WEIGHTS = {
+    'real madrid': 12,
+    'barcelona': 12,
+    'bayern munich': 12,
+    'liverpool': 12,
+    'manchester city': 12,
+    'paris saint-germain': 12,
+    'arsenal': 12,
+    'chelsea': 12,
+    'inter': 12,
+    'manchester united': 12,
+    'atletico madrid': 8,
+    'borussia dortmund': 8,
+    'juventus': 8,
+    'ac milan': 8,
+    'tottenham hotspur': 8,
+    'newcastle united': 8,
+    'bayer leverkusen': 8,
+    'napoli': 8,
+    'roma': 8,
+    'benfica': 8,
+}
+
+TEAM_ALIASES = {
+    'psg': 'paris saint-germain',
+    'paris sg': 'paris saint-germain',
+    'paris saint germain': 'paris saint-germain',
+    'man city': 'manchester city',
+    'manchester city': 'manchester city',
+    'man utd': 'manchester united',
+    'man united': 'manchester united',
+    'manchester utd': 'manchester united',
+    'manchester united': 'manchester united',
+    'atletico': 'atletico madrid',
+    'atletico de madrid': 'atletico madrid',
+    'inter milan': 'inter',
+    'internazionale': 'inter',
+    'milan': 'ac milan',
+    'tottenham': 'tottenham hotspur',
+    'spurs': 'tottenham hotspur',
+    'newcastle': 'newcastle united',
+    'bayern': 'bayern munich',
+    'atletico madrid': 'atletico madrid',
+    'borussia monchengladbach': 'borussia monchengladbach',
+}
+
+STAGE_BONUSES = (
+    (('1/2 финала', 'semi'), 14),
+    (('1/4 финала', 'quarter'), 10),
+    (('1/8 финала', 'round of 16'), 7),
+    (('1/16 финала', 'round of 32'), 5),
+    (('. финал', ' final'), 18),
+)
 
 
 def _extract_coverage_metrics(table_data: Dict) -> Tuple[int, int]:
@@ -170,6 +231,13 @@ class SportsDBSyncer:
         """Получить top-N матчей на ближайшие 3 дня (default mode)"""
         all_matches = []
         sync_dates = self._get_sync_dates()
+        candidates = self._collect_top3_candidates(sync_dates)
+        selected = self._select_top_matches_with_day_quotas(
+            candidates,
+            self.limit
+        )
+        selected.sort(key=lambda x: (x['match_date'], x['match_time']))
+        return selected
 
         logger.info(
             f"Режим top3: получение {self.limit} матчей "
@@ -205,6 +273,262 @@ class SportsDBSyncer:
         # Сортируем по дате/времени (ближайшие первые)
         unique.sort(key=lambda x: (x['match_date'], x['match_time']))
         return unique
+
+    def _collect_top3_candidates(self, sync_dates) -> List[Dict]:
+        """Собрать и дедуплицировать кандидатов для top3 за окно sync_days."""
+        all_matches = []
+        all_tournaments = self.top_leagues + self.cups
+
+        logger.info(
+            "Режим top3: получение %s матчей на %s - %s...",
+            self.limit,
+            sync_dates[0],
+            sync_dates[-1],
+        )
+
+        for league in all_tournaments:
+            try:
+                logger.info("Получение матчей из: %s", league['name'])
+                data = self.api.make_request(
+                    "eventsnextleague.php", {"id": league['id']}
+                )
+                if not data or 'events' not in data or not data['events']:
+                    continue
+                for event in data['events']:
+                    match = self._parse_event(event)
+                    if not match or match['match_date'] not in sync_dates:
+                        continue
+                    all_matches.append(match)
+                time.sleep(0.5)
+            except Exception as e:
+                logger.error("Ошибка для %s: %s", league['name'], e)
+                continue
+
+        logger.info("Top3 кандидатов собрано до дедупликации: %s", len(all_matches))
+        unique = self._remove_duplicates(all_matches)
+        logger.info("Top3 кандидатов после дедупликации: %s", len(unique))
+        return unique
+
+    @staticmethod
+    def _canonicalize_text(value: str) -> str:
+        text = str(value or '').strip().lower()
+        text = unicodedata.normalize('NFKD', text)
+        text = ''.join(char for char in text if not unicodedata.combining(char))
+        text = (
+            text.replace('\u2019', "'")
+            .replace('\u2018', "'")
+            .replace('\u2010', '-')
+            .replace('\u2011', '-')
+            .replace('\u2012', '-')
+            .replace('\u2013', '-')
+            .replace('\u2014', '-')
+            .replace('\u2212', '-')
+        )
+        text = text.replace('-', ' ')
+        text = text.replace("'", ' ')
+        text = re.sub(r'\s+', ' ', text)
+        return text.strip()
+
+    @staticmethod
+    def _normalize_team_name(team_name: str) -> str:
+        normalized = SportsDBSyncer._canonicalize_text(team_name)
+        return TEAM_ALIASES.get(normalized, normalized)
+
+    def _get_team_weight(self, team_name: str) -> int:
+        normalized = self._normalize_team_name(team_name)
+        return TEAM_TIER_WEIGHTS.get(normalized, 0)
+
+    def _get_league_weight(self, league_name: str) -> int:
+        league_lc = str(league_name or '').lower()
+        for label, weight in LEAGUE_WEIGHTS.items():
+            if label in league_lc:
+                return weight
+        return 12
+
+    def _get_stage_bonus(self, league_name: str) -> int:
+        league_lc = str(league_name or '').lower()
+        for markers, bonus in STAGE_BONUSES:
+            if any(marker in league_lc for marker in markers):
+                return bonus
+        return 0
+
+    def _get_matchup_bonus(self, team1: str, team2: str) -> int:
+        team1_weight = self._get_team_weight(team1)
+        team2_weight = self._get_team_weight(team2)
+        is_team1_tier_a = team1_weight >= 12
+        is_team2_tier_a = team2_weight >= 12
+        is_team1_tier_b = team1_weight >= 8
+        is_team2_tier_b = team2_weight >= 8
+
+        if is_team1_tier_a and is_team2_tier_a:
+            return 12
+        if (is_team1_tier_a and is_team2_tier_b) or (is_team2_tier_a and is_team1_tier_b):
+            return 7
+        if is_team1_tier_b and is_team2_tier_b:
+            return 5
+        return 0
+
+    def _get_premium_pair_bonus(self, match: Dict) -> int:
+        league_weight = self._get_league_weight(match.get('league'))
+        team_weight = (
+            self._get_team_weight(match.get('team1'))
+            + self._get_team_weight(match.get('team2'))
+        )
+        if league_weight >= 28 and team_weight >= 16:
+            return 4
+        return 0
+
+    def _get_neutral_match_penalty(self, match: Dict) -> int:
+        team1_weight = self._get_team_weight(match.get('team1'))
+        team2_weight = self._get_team_weight(match.get('team2'))
+        matchup_bonus = self._get_matchup_bonus(match.get('team1'), match.get('team2'))
+        stage_bonus = self._get_stage_bonus(match.get('league'))
+        if (
+            team1_weight == 0
+            and team2_weight == 0
+            and matchup_bonus == 0
+            and stage_bonus == 0
+        ):
+            return 4
+        return 0
+
+    def _score_match_breakdown(self, match: Dict) -> Dict[str, int]:
+        league_weight = self._get_league_weight(match.get('league'))
+        team1_weight = self._get_team_weight(match.get('team1'))
+        team2_weight = self._get_team_weight(match.get('team2'))
+        matchup_bonus = self._get_matchup_bonus(match.get('team1'), match.get('team2'))
+        stage_bonus = self._get_stage_bonus(match.get('league'))
+        premium_pair_bonus = self._get_premium_pair_bonus(match)
+        neutral_match_penalty = self._get_neutral_match_penalty(match)
+        return {
+            'league': league_weight,
+            'team': team1_weight + team2_weight,
+            'matchup': matchup_bonus,
+            'stage': stage_bonus,
+            'premium_pair': premium_pair_bonus,
+            'penalty': neutral_match_penalty,
+            'total': (
+                league_weight
+                + team1_weight
+                + team2_weight
+                + matchup_bonus
+                + stage_bonus
+                + premium_pair_bonus
+                - neutral_match_penalty
+            ),
+        }
+
+    def _score_match(self, match: Dict) -> int:
+        return self._score_match_breakdown(match)['total']
+
+    def _match_sort_key(self, match: Dict):
+        return (
+            -self._score_match(match),
+            match['match_date'],
+            match['match_time'],
+            match.get('league', ''),
+            match.get('team1', ''),
+            match.get('team2', ''),
+        )
+
+    def _match_identity(self, match: Dict):
+        return match.get('api_event_id') or (
+            match.get('team1'),
+            match.get('team2'),
+            str(match.get('match_date')),
+        )
+
+    def _log_selected_match(self, prefix: str, match: Dict) -> None:
+        breakdown = self._score_match_breakdown(match)
+        logger.debug(
+            "%s %s vs %s [%s %s] league=%s team=%s matchup=%s stage=%s premium_pair=%s penalty=%s total=%s",
+            prefix,
+            match.get('team1'),
+            match.get('team2'),
+            match.get('match_date'),
+            match.get('match_time'),
+            breakdown['league'],
+            breakdown['team'],
+            breakdown['matchup'],
+            breakdown['stage'],
+            breakdown['premium_pair'],
+            breakdown['penalty'],
+            breakdown['total'],
+        )
+
+    def _log_selected_match_info(self, origin: str, match: Dict) -> None:
+        logger.info(
+            "Top3 selected [%s] %s %s | %s vs %s | score=%s",
+            origin,
+            match.get('match_date'),
+            match.get('match_time'),
+            match.get('team1'),
+            match.get('team2'),
+            self._score_match(match),
+        )
+
+    def _select_top_matches_with_day_quotas(self, matches: List[Dict], limit: int) -> List[Dict]:
+        """Выбрать top-N матчей по score с мягкими квотами по дням."""
+        if not matches or limit <= 0:
+            return []
+
+        ranked_matches = sorted(matches, key=self._match_sort_key)
+        if limit < 9:
+            selected = ranked_matches[:limit]
+            logger.info(
+                "Top3: лимит %s < 9, квоты по дням не применяются, выбран глобальный score",
+                limit
+            )
+            for match in selected:
+                self._log_selected_match("Top3 score:", match)
+                self._log_selected_match_info("G", match)
+            return selected
+
+        matches_by_date = defaultdict(list)
+        for match in ranked_matches:
+            matches_by_date[match['match_date']].append(match)
+
+        min_per_day = 3
+        selected = []
+        selected_ids = set()
+        quota_counts = {}
+
+        for match_date in sorted(matches_by_date.keys()):
+            day_selected = 0
+            for match in matches_by_date[match_date]:
+                if day_selected >= min_per_day or len(selected) >= limit:
+                    break
+                match_key = self._match_identity(match)
+                if match_key in selected_ids:
+                    continue
+                selected.append(match)
+                selected_ids.add(match_key)
+                day_selected += 1
+                self._log_selected_match("Top3 quota:", match)
+                self._log_selected_match_info("Q", match)
+            quota_counts[str(match_date)] = day_selected
+
+        logger.info("Top3: квоты по дням применены %s", quota_counts)
+
+        for match in ranked_matches:
+            if len(selected) >= limit:
+                break
+            match_key = self._match_identity(match)
+            if match_key in selected_ids:
+                continue
+            selected.append(match)
+            selected_ids.add(match_key)
+            self._log_selected_match("Top3 global:", match)
+            self._log_selected_match_info("G", match)
+
+        logger.info(
+            "Top3: отобрано %s матчей из %s кандидатов (quota=%s, global=%s)",
+            len(selected),
+            len(matches),
+            sum(quota_counts.values()),
+            max(0, len(selected) - sum(quota_counts.values()))
+        )
+        return selected[:limit]
 
     def get_week_matches(self) -> List[Dict]:
         """Получить ВСЕ матчи из всех лиг и кубков на ближайшие 3 дня"""
@@ -700,6 +1024,12 @@ def run_coverage_check(
 
 
 def main():
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+
     parser = argparse.ArgumentParser(
         description='Синхронизация матчей из TheSportsDB API'
     )

--- a/tests/test_bot_profile.py
+++ b/tests/test_bot_profile.py
@@ -1,0 +1,67 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import bot_profile
+
+
+def test_build_dynamic_description_variants(monkeypatch):
+    monkeypatch.setattr(bot_profile, "datetime", FakeDateTime)
+    assert bot_profile.build_dynamic_description([]) == bot_profile.FALLBACK_DESCRIPTION
+
+    description = bot_profile.build_dynamic_description(
+        [
+            {"team1": "A", "team2": "B", "match_time": "12:00", "match_date": "2026-03-07"},
+            {"team1": "C", "team2": "D", "match_time": "14:00", "match_date": "2026-03-08"},
+        ]
+    )
+
+    assert "🔥 Самые интересные матчи с AI-разбором:" in description
+    assert "A - B — Сегодня, 12:00" in description
+    assert "C - D — Завтра, 14:00" in description
+    assert "Нажмите Start и выберите матч!" in description
+
+
+def test_update_dynamic_description_uses_selected_matches(monkeypatch):
+    now = datetime(2026, 3, 7, 12, 0)
+    bot = AsyncMock()
+    candidates = [
+        {"team1": "A", "team2": "B", "match_time": "12:00", "match_date": "2026-03-07"},
+        {"team1": "C", "team2": "D", "match_time": "14:00", "match_date": "2026-03-08"},
+    ]
+    selected = [candidates[1]]
+    logged = []
+
+    monkeypatch.setattr(bot_profile.database, "get_visible_profile_candidates", lambda **kwargs: candidates)
+    monkeypatch.setattr(bot_profile, "select_profile_matches", lambda matches, now, limit=3: selected)
+    monkeypatch.setattr(bot_profile, "datetime", FakeDateTime)
+    monkeypatch.setattr(
+        bot_profile,
+        "get_profile_score_breakdown",
+        lambda match, now: {"catalog_score": 42, "time_boost": 3, "profile_score": 45},
+    )
+    monkeypatch.setattr(bot_profile.logger, "info", lambda message, *args: logged.append((message, args)))
+
+    description = asyncio.run(bot_profile.update_dynamic_description(bot, now=now))
+
+    bot.set_my_description.assert_awaited_once_with(description=description)
+    assert "C - D — Завтра, 14:00" in description
+    assert any(
+        entry[0].startswith("Description selected:")
+        and entry[1][0] == "C"
+        and entry[1][1] == "D"
+        and entry[1][4] == 42
+        and entry[1][5] == 3
+        and entry[1][6] == 45
+        for entry in logged
+    )
+
+
+class FakeDateTime:
+    @staticmethod
+    def now():
+        return datetime(2026, 3, 7, 12, 0)
+
+    @staticmethod
+    def strptime(value, fmt):
+        return datetime.strptime(value, fmt)

--- a/tests/test_database_queries.py
+++ b/tests/test_database_queries.py
@@ -197,6 +197,53 @@ def test_get_matches_by_date_filtered_hides_old_or_uncovered_matches(helpers, mo
     assert uncovered not in result_ids
 
 
+def test_get_visible_profile_candidates_respects_window_and_visibility(helpers, monkeypatch):
+    frozen_now = datetime(2026, 3, 4, 12, 0, 0)
+
+    class FrozenDateTime:
+        @staticmethod
+        def now():
+            return frozen_now
+
+        @staticmethod
+        def strptime(value, fmt):
+            return datetime.strptime(value, fmt)
+
+    monkeypatch.setattr(database, "datetime", FrozenDateTime)
+
+    today = frozen_now.strftime("%Y-%m-%d")
+    tomorrow = (frozen_now + timedelta(days=1)).strftime("%Y-%m-%d")
+    third_day = (frozen_now + timedelta(days=2)).strftime("%Y-%m-%d")
+    far_day = (frozen_now + timedelta(days=3)).strftime("%Y-%m-%d")
+    future_today = helpers["create_match"](team1="Today", team2="Soon", match_date=today, match_time="13:00", api_event_id="profile-1")
+    recent_live = helpers["create_match"](team1="Live", team2="Now", match_date=today, match_time="10:30", api_event_id="profile-2")
+    stale = helpers["create_match"](team1="Too", team2="Old", match_date=today, match_time="08:00", api_event_id="profile-3")
+    tomorrow_match = helpers["create_match"](team1="Next", team2="Day", match_date=tomorrow, match_time="16:00", api_event_id="profile-4")
+    third_day_match = helpers["create_match"](team1="Third", team2="Day", match_date=third_day, match_time="18:00", api_event_id="profile-5")
+    far_match = helpers["create_match"](team1="Far", team2="Away", match_date=far_day, match_time="18:00", api_event_id="profile-6")
+    hidden = helpers["create_match"](team1="No", team2="Coverage", match_date=today, match_time="15:00", api_event_id="profile-7")
+    inactive = helpers["create_match"](team1="No", team2="Active", match_date=today, match_time="15:30", api_event_id="profile-8")
+    basketball = helpers["create_match"](team1="Ball", team2="Hoop", sport="basketball", match_date=today, match_time="14:00", api_event_id="profile-9")
+
+    for match_id in (future_today, recent_live, stale, tomorrow_match, third_day_match, far_match, hidden, inactive, basketball):
+        helpers["update_match"](match_id, coverage_ok=1)
+    helpers["update_match"](hidden, coverage_ok=0)
+    helpers["update_match"](inactive, is_active=0)
+
+    results = database.get_visible_profile_candidates(now=frozen_now)
+    result_ids = [row["id"] for row in results]
+
+    assert future_today in result_ids
+    assert recent_live in result_ids
+    assert tomorrow_match in result_ids
+    assert third_day_match in result_ids
+    assert stale not in result_ids
+    assert far_match not in result_ids
+    assert hidden not in result_ids
+    assert inactive not in result_ids
+    assert basketball not in result_ids
+
+
 def test_purchase_query_helpers(helpers):
     user = helpers["create_user"](201, "buyer", balance=0)
     match_paid = helpers["create_match"](team1="Paid", team2="Match", api_event_id="paid-1")
@@ -278,12 +325,14 @@ def test_topup_helpers(helpers):
 
 def test_match_crud_helpers_and_cleanup(helpers, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    active_date = datetime.now().strftime("%Y-%m-%d")
+    fallback_date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
     new_id, is_new = database.sync_match_from_api(
         {
             "sport": "football",
             "team1": "Sync",
             "team2": "Created",
-            "match_date": "2026-03-04",
+            "match_date": active_date,
             "match_time": "21:00",
             "league": "Cup",
             "api_event_id": "api-100",
@@ -295,7 +344,7 @@ def test_match_crud_helpers_and_cleanup(helpers, tmp_path, monkeypatch):
             "sport": "football",
             "team1": "Sync",
             "team2": "Created",
-            "match_date": "2026-03-04",
+            "match_date": active_date,
             "match_time": "21:00",
             "league": "Cup",
             "api_event_id": "api-100",
@@ -306,7 +355,7 @@ def test_match_crud_helpers_and_cleanup(helpers, tmp_path, monkeypatch):
             "sport": "football",
             "team1": "Fallback",
             "team2": "Teams",
-            "match_date": "2026-03-05",
+            "match_date": fallback_date,
             "match_time": "19:00",
         }
     )
@@ -315,7 +364,7 @@ def test_match_crud_helpers_and_cleanup(helpers, tmp_path, monkeypatch):
             "sport": "football",
             "team1": "Fallback",
             "team2": "Teams",
-            "match_date": "2026-03-05",
+            "match_date": fallback_date,
             "match_time": "22:00",
         }
     )

--- a/tests/test_main_error_handler.py
+++ b/tests/test_main_error_handler.py
@@ -1,0 +1,82 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from telegram.error import NetworkError
+
+import main
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def test_error_handler_logs_non_network_errors_as_error(monkeypatch):
+    error_mock = Mock()
+    warning_mock = Mock()
+
+    monkeypatch.setattr(main.logger, "error", error_mock)
+    monkeypatch.setattr(main.logger, "warning", warning_mock)
+    main._ptb_net_error_state["count"] = 3
+    main._ptb_net_error_state["last_at"] = 123.0
+
+    run_async(main.error_handler(None, SimpleNamespace(error=RuntimeError("boom"))))
+
+    warning_mock.assert_not_called()
+    error_mock.assert_called_once()
+    assert main._ptb_net_error_state == {"count": 0, "last_at": 0.0}
+
+
+def test_error_handler_warns_on_single_network_error(monkeypatch):
+    error_mock = Mock()
+    warning_mock = Mock()
+
+    monkeypatch.setattr(main.logger, "error", error_mock)
+    monkeypatch.setattr(main.logger, "warning", warning_mock)
+    monkeypatch.setattr(main, "_ptb_monotonic", lambda: 100.0)
+    main._reset_ptb_network_error_state()
+
+    run_async(main.error_handler(None, SimpleNamespace(error=NetworkError("connect failed"))))
+
+    error_mock.assert_not_called()
+    warning_mock.assert_called_once()
+    assert "попытка %s" in warning_mock.call_args.args[0]
+    assert warning_mock.call_args.args[2] == 1
+
+
+def test_error_handler_escalates_after_network_error_series(monkeypatch):
+    error_mock = Mock()
+    warning_mock = Mock()
+    monotonic_values = iter([100.0, 110.0, 120.0, 130.0, 140.0])
+
+    monkeypatch.setattr(main.logger, "error", error_mock)
+    monkeypatch.setattr(main.logger, "warning", warning_mock)
+    monkeypatch.setattr(main, "_ptb_monotonic", lambda: next(monotonic_values))
+    main._reset_ptb_network_error_state()
+
+    for _ in range(main.PTB_NET_ERROR_ESCALATE_AFTER):
+        run_async(main.error_handler(None, SimpleNamespace(error=NetworkError("connect failed"))))
+
+    assert warning_mock.call_count == main.PTB_NET_ERROR_ESCALATE_AFTER - 1
+    error_mock.assert_called_once()
+    assert "Telegram API недоступен уже" in error_mock.call_args.args[0]
+    assert error_mock.call_args.args[2] == main.PTB_NET_ERROR_ESCALATE_AFTER
+
+
+def test_error_handler_resets_network_series_after_long_gap(monkeypatch):
+    error_mock = Mock()
+    warning_mock = Mock()
+    monotonic_values = iter([100.0, 400.0])
+
+    monkeypatch.setattr(main.logger, "error", error_mock)
+    monkeypatch.setattr(main.logger, "warning", warning_mock)
+    monkeypatch.setattr(main, "_ptb_monotonic", lambda: next(monotonic_values))
+    main._reset_ptb_network_error_state()
+
+    run_async(main.error_handler(None, SimpleNamespace(error=NetworkError("connect failed"))))
+    run_async(main.error_handler(None, SimpleNamespace(error=NetworkError("connect failed"))))
+
+    error_mock.assert_not_called()
+    assert warning_mock.call_count == 2
+    assert warning_mock.call_args_list[0].args[2] == 1
+    assert warning_mock.call_args_list[1].args[2] == 1

--- a/tests/test_main_profile_updates.py
+++ b/tests/test_main_profile_updates.py
@@ -1,0 +1,20 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import main
+
+
+def test_refresh_dynamic_description_logs_warning_on_failure(monkeypatch):
+    bot = object()
+    warnings = []
+
+    async def fail_update(_bot):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(main, "update_dynamic_description", fail_update)
+    monkeypatch.setattr(main.logger, "warning", lambda message, reason, error: warnings.append((message, reason, str(error))))
+
+    asyncio.run(main._refresh_dynamic_description(bot, "test"))
+
+    assert warnings
+    assert warnings[0][1] == "test"

--- a/tests/test_profile_ranking.py
+++ b/tests/test_profile_ranking.py
@@ -1,0 +1,133 @@
+import sqlite3
+from datetime import datetime, timedelta
+
+from profile_ranking import compute_catalog_score, compute_profile_score, select_profile_matches
+from sync_matches import SportsDBSyncer
+
+
+def _match(team1, team2, league, match_date, match_time):
+    return {
+        "team1": team1,
+        "team2": team2,
+        "league": league,
+        "match_date": match_date,
+        "match_time": match_time,
+    }
+
+
+def _sqlite_row_from_match(match):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE matches (
+            team1 TEXT,
+            team2 TEXT,
+            league TEXT,
+            match_date TEXT,
+            match_time TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO matches (team1, team2, league, match_date, match_time)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            match["team1"],
+            match["team2"],
+            match["league"],
+            match["match_date"],
+            match["match_time"],
+        ),
+    )
+    row = conn.execute("SELECT * FROM matches").fetchone()
+    conn.close()
+    return row
+
+
+def test_compute_catalog_score_matches_sync_logic():
+    syncer = SportsDBSyncer()
+    match = _match(
+        "Liverpool",
+        "Manchester United",
+        "UEFA Champions League. 1/2 финала",
+        "2026-03-08",
+        "22:00",
+    )
+
+    assert compute_catalog_score(match) == syncer._score_match(match)
+
+
+def test_compute_profile_score_prioritizes_near_future_over_tomorrow():
+    now = datetime(2026, 3, 7, 12, 0)
+    today_match = _match(
+        "Arsenal",
+        "Chelsea",
+        "Premier League",
+        "2026-03-07",
+        "14:00",
+    )
+    tomorrow_match = _match(
+        "Arsenal",
+        "Chelsea",
+        "Premier League",
+        "2026-03-08",
+        "14:00",
+    )
+
+    assert compute_profile_score(today_match, now) > compute_profile_score(tomorrow_match, now)
+
+
+def test_compute_profile_score_penalizes_recent_live_match():
+    now = datetime(2026, 3, 7, 12, 0)
+    live_match = _match(
+        "Arsenal",
+        "Chelsea",
+        "Premier League",
+        "2026-03-07",
+        "10:30",
+    )
+    future_match = _match(
+        "Arsenal",
+        "Chelsea",
+        "Premier League",
+        "2026-03-07",
+        "14:00",
+    )
+
+    assert compute_profile_score(future_match, now) > compute_profile_score(live_match, now)
+
+
+def test_select_profile_matches_uses_profile_sorting():
+    now = datetime(2026, 3, 7, 12, 0)
+    matches = [
+        _match("Arsenal", "Chelsea", "Premier League", "2026-03-08", "14:00"),
+        _match("Liverpool", "Manchester United", "Premier League", "2026-03-07", "16:00"),
+        _match("Real Madrid", "Barcelona", "La Liga", "2026-03-09", "21:00"),
+        _match("Inter", "Juventus", "Serie A", "2026-03-07", "19:00"),
+    ]
+
+    selected = select_profile_matches(matches, now, limit=3)
+
+    assert len(selected) == 3
+    assert [match["team1"] for match in selected] == ["Liverpool", "Arsenal", "Real Madrid"]
+
+
+def test_profile_ranking_accepts_sqlite_rows():
+    now = datetime(2026, 3, 7, 12, 0)
+    row = _sqlite_row_from_match(
+        _match(
+            "Liverpool",
+            "Manchester United",
+            "Premier League",
+            "2026-03-07",
+            "16:00",
+        )
+    )
+
+    assert compute_catalog_score(row) > 0
+    selected = select_profile_matches([row], now, limit=1)
+    assert len(selected) == 1
+    assert selected[0]["team1"] == "Liverpool"

--- a/tests/test_sync_matches.py
+++ b/tests/test_sync_matches.py
@@ -1,6 +1,7 @@
 """Интеграционные тесты для sync_matches.py."""
 import sys
 import os
+import logging
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta
@@ -68,6 +69,28 @@ MOCK_EVENTS_RESPONSE = {
         },
     ]
 }
+
+
+def _build_match(
+    api_event_id,
+    team1,
+    team2,
+    match_date,
+    match_time,
+    league,
+):
+    return {
+        "sport": "football",
+        "team1": team1,
+        "team2": team2,
+        "match_date": match_date,
+        "match_time": match_time,
+        "league": league,
+        "api_event_id": api_event_id,
+        "price": 150,
+        "is_active": 1,
+        "source": "TheSportsDB",
+    }
 
 # SQL для создания тестовой схемы
 CREATE_MATCHES_SQL = '''
@@ -299,6 +322,383 @@ class TestBulkMode:
             assert results['inserted'] + results['skipped'] == results['total']
         finally:
             os.unlink(db_path)
+
+
+class TestTop3Ranking:
+    """Тесты гибридного рейтинга и мягких квот по дням."""
+
+    def test_normalize_team_name_strips_diacritics(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+
+        assert syncer._normalize_team_name("Atlético Madrid") == "atletico madrid"
+        assert syncer._normalize_team_name("Paris SG") == "paris saint-germain"
+        assert syncer._normalize_team_name("Inter Milan") == "inter"
+
+    def test_accented_team_name_gets_same_weight(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+
+        assert syncer._get_team_weight("Atlético Madrid") == syncer._get_team_weight("Atletico Madrid")
+        assert syncer._get_team_weight("Atlético Madrid") == 8
+
+    def test_accented_tier_team_outranks_non_tier_match(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        accented_match = _build_match(
+            "accented",
+            "Atlético Madrid",
+            "Real Sociedad",
+            _today,
+            "20:30",
+            "La Liga. 27 тур",
+        )
+        regular_match = _build_match(
+            "regular-accent",
+            "Osasuna",
+            "Mallorca",
+            _today,
+            "20:30",
+            "La Liga. 27 тур",
+        )
+
+        assert syncer._score_match(accented_match) > syncer._score_match(regular_match)
+
+    def test_day_quotas_keep_all_three_days_in_limit_15(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        day0 = _today
+        day1 = _today + timedelta(days=1)
+        day2 = _today + timedelta(days=2)
+        matches = []
+
+        for idx in range(6):
+            matches.append(
+                _build_match(
+                    f"d0-{idx}",
+                    f"Day0 Team {idx}",
+                    f"Day0 Opp {idx}",
+                    day0,
+                    f"{12 + idx:02d}:00",
+                    "Premier League. 30 тур",
+                )
+            )
+        for idx in range(6):
+            matches.append(
+                _build_match(
+                    f"d1-{idx}",
+                    f"Day1 Team {idx}",
+                    f"Day1 Opp {idx}",
+                    day1,
+                    f"{12 + idx:02d}:00",
+                    "La Liga. 27 тур",
+                )
+            )
+        matches.extend([
+            _build_match("d2-0", "Real Madrid", "Barcelona", day2, "20:00", "UEFA Champions League. 1/8 финала"),
+            _build_match("d2-1", "Arsenal", "Chelsea", day2, "18:00", "Premier League. 30 тур"),
+            _build_match("d2-2", "Benfica", "Roma", day2, "16:00", "UEFA Europa League. 1/8 финала"),
+            _build_match("d2-3", "Day2 Team 3", "Day2 Opp 3", day2, "14:00", "Ligue 1. 22 тур"),
+            _build_match("d2-4", "Day2 Team 4", "Day2 Opp 4", day2, "12:00", "Bundesliga. 24 тур"),
+        ])
+
+        selected = syncer._select_top_matches_with_day_quotas(matches, limit=15)
+
+        counts = {}
+        for match in selected:
+            counts[str(match["match_date"])] = counts.get(str(match["match_date"]), 0) + 1
+
+        assert len(selected) == 15
+        assert counts[str(day0)] >= 3
+        assert counts[str(day1)] >= 3
+        assert counts[str(day2)] >= 3
+
+    def test_missing_day_capacity_is_redistributed(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        day0 = _today
+        day1 = _today + timedelta(days=1)
+        day2 = _today + timedelta(days=2)
+        matches = [
+            _build_match("d2-0", "Real Madrid", "Barcelona", day2, "20:00", "UEFA Champions League. 1/8 финала"),
+            _build_match("d2-1", "Arsenal", "Chelsea", day2, "18:00", "Premier League. 30 тур"),
+        ]
+
+        for idx in range(8):
+            matches.append(
+                _build_match(
+                    f"d0-{idx}",
+                    f"Day0 Team {idx}",
+                    f"Day0 Opp {idx}",
+                    day0,
+                    f"{10 + idx:02d}:00",
+                    "Premier League. 30 тур",
+                )
+            )
+        for idx in range(8):
+            matches.append(
+                _build_match(
+                    f"d1-{idx}",
+                    f"Day1 Team {idx}",
+                    f"Day1 Opp {idx}",
+                    day1,
+                    f"{10 + idx:02d}:00",
+                    "Serie A. 28 тур",
+                )
+            )
+
+        selected = syncer._select_top_matches_with_day_quotas(matches, limit=15)
+        counts = {}
+        for match in selected:
+            counts[str(match["match_date"])] = counts.get(str(match["match_date"]), 0) + 1
+
+        assert len(selected) == 15
+        assert counts[str(day2)] == 2
+        assert counts[str(day0)] + counts[str(day1)] == 13
+
+    def test_strong_match_on_third_day_survives_dense_first_days(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        day0 = _today
+        day1 = _today + timedelta(days=1)
+        day2 = _today + timedelta(days=2)
+        matches = []
+
+        for idx in range(10):
+            matches.append(
+                _build_match(
+                    f"d0-{idx}",
+                    f"Mid Day0 {idx}",
+                    f"Opp Day0 {idx}",
+                    day0,
+                    f"{10 + idx:02d}:00",
+                    "Ligue 1. 22 тур",
+                )
+            )
+        for idx in range(10):
+            matches.append(
+                _build_match(
+                    f"d1-{idx}",
+                    f"Mid Day1 {idx}",
+                    f"Opp Day1 {idx}",
+                    day1,
+                    f"{10 + idx:02d}:00",
+                    "Bundesliga. 24 тур",
+                )
+            )
+        marquee = _build_match(
+            "d2-marquee",
+            "Real Madrid",
+            "Barcelona",
+            day2,
+            "21:00",
+            "UEFA Champions League. 1/4 финала",
+        )
+        matches.extend([
+            marquee,
+            _build_match("d2-1", "Arsenal", "Chelsea", day2, "19:00", "Premier League. 30 тур"),
+            _build_match("d2-2", "Benfica", "Roma", day2, "17:00", "UEFA Europa League. 1/8 финала"),
+        ])
+
+        selected = syncer._select_top_matches_with_day_quotas(matches, limit=15)
+
+        assert any(match["api_event_id"] == "d2-marquee" for match in selected)
+
+    def test_tier_a_match_outranks_regular_same_league_match(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        big_match = _build_match(
+            "big",
+            "Arsenal",
+            "Chelsea",
+            _today,
+            "19:00",
+            "Premier League. 30 тур",
+        )
+        regular_match = _build_match(
+            "regular",
+            "Wolves",
+            "Brentford",
+            _today,
+            "18:00",
+            "Premier League. 30 тур",
+        )
+
+        assert syncer._score_match(big_match) > syncer._score_match(regular_match)
+
+    def test_tier_a_and_tier_b_match_outranks_regular_same_league_match(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        premium_match = _build_match(
+            "premium",
+            "Arsenal",
+            "Roma",
+            _today,
+            "19:00",
+            "Premier League. 30 С‚СѓСЂ",
+        )
+        regular_match = _build_match(
+            "regular-ab",
+            "Wolves",
+            "Brentford",
+            _today,
+            "18:00",
+            "Premier League. 30 С‚СѓСЂ",
+        )
+
+        assert syncer._score_match(premium_match) > syncer._score_match(regular_match)
+
+    def test_ucl_outranks_mid_tier_league_match(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        ucl_match = _build_match(
+            "ucl",
+            "Benfica",
+            "Roma",
+            _today,
+            "20:00",
+            "UEFA Champions League. 1/8 финала",
+        )
+        league_match = _build_match(
+            "league",
+            "Day Team 1",
+            "Day Team 2",
+            _today,
+            "18:00",
+            "Ligue 1. 22 тур",
+        )
+
+        assert syncer._score_match(ucl_match) > syncer._score_match(league_match)
+
+    def test_stage_bonus_boosts_playoff_match(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        playoff_match = _build_match(
+            "playoff",
+            "Benfica",
+            "Roma",
+            _today,
+            "20:00",
+            "UEFA Europa League. 1/4 финала",
+        )
+        league_match = _build_match(
+            "league",
+            "Benfica",
+            "Roma",
+            _today,
+            "20:00",
+            "UEFA Europa League",
+        )
+
+        assert syncer._score_match(playoff_match) > syncer._score_match(league_match)
+
+    def test_neutral_match_penalty_is_applied(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        neutral_match = _build_match(
+            "neutral",
+            "Team A",
+            "Team B",
+            _today,
+            "20:00",
+            "La Liga. 27 С‚СѓСЂ",
+        )
+
+        breakdown = syncer._score_match_breakdown(neutral_match)
+
+        assert breakdown["penalty"] == 4
+        assert breakdown["total"] == 26
+
+    def test_neutral_match_penalty_not_applied_to_playoff_match(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        playoff_match = _build_match(
+            "neutral-playoff",
+            "Team A",
+            "Team B",
+            _today,
+            "20:00",
+            "UEFA Europa League. Quarter-final",
+        )
+
+        breakdown = syncer._score_match_breakdown(playoff_match)
+
+        assert breakdown["stage"] == 10
+        assert breakdown["penalty"] == 0
+
+    def test_premium_pair_bonus_applies_only_for_strong_league_and_team_weight(self):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        premium_match = _build_match(
+            "premium-pair",
+            "Arsenal",
+            "Roma",
+            _today,
+            "20:00",
+            "Premier League. 30 С‚СѓСЂ",
+        )
+        not_premium_match = _build_match(
+            "not-premium-pair",
+            "Arsenal",
+            "Roma",
+            _today,
+            "20:00",
+            "Ligue 1. 22 С‚СѓСЂ",
+        )
+
+        assert syncer._get_premium_pair_bonus(premium_match) == 4
+        assert syncer._get_premium_pair_bonus(not_premium_match) == 0
+
+    def test_limit_below_9_skips_day_quotas(self):
+        syncer = SportsDBSyncer(mode="top3", limit=2)
+        day0 = _today
+        day1 = _today + timedelta(days=1)
+        matches = [
+            _build_match("day1-big", "Real Madrid", "Barcelona", day1, "21:00", "UEFA Champions League. 1/4 финала"),
+            _build_match("day1-mid", "Arsenal", "Chelsea", day1, "19:00", "Premier League. 30 тур"),
+            _build_match("day0-low", "Team A", "Team B", day0, "11:00", "Ligue 1. 22 тур"),
+            _build_match("day0-low2", "Team C", "Team D", day0, "12:00", "Ligue 1. 22 тур"),
+        ]
+
+        selected = syncer._select_top_matches_with_day_quotas(matches, limit=2)
+
+        assert len(selected) == 2
+        assert [match["api_event_id"] for match in selected] == ["day1-big", "day1-mid"]
+
+    def test_selected_matches_are_logged_in_info(self, caplog):
+        syncer = SportsDBSyncer(mode="top3", limit=15)
+        day0 = _today
+        day1 = _today + timedelta(days=1)
+        day2 = _today + timedelta(days=2)
+        matches = []
+
+        for idx in range(4):
+            matches.append(
+                _build_match(
+                    f"d0-{idx}",
+                    f"Day0 Team {idx}",
+                    f"Day0 Opp {idx}",
+                    day0,
+                    f"{12 + idx:02d}:00",
+                    "Premier League. 30 С‚СѓСЂ",
+                )
+            )
+            matches.append(
+                _build_match(
+                    f"d1-{idx}",
+                    f"Day1 Team {idx}",
+                    f"Day1 Opp {idx}",
+                    day1,
+                    f"{12 + idx:02d}:00",
+                    "La Liga. 27 С‚СѓСЂ",
+                )
+            )
+        matches.extend([
+            _build_match("d2-0", "Real Madrid", "Barcelona", day2, "20:00", "UEFA Champions League. 1/8 С„РёРЅР°Р»Р°"),
+            _build_match("d2-1", "Arsenal", "Chelsea", day2, "18:00", "Premier League. 30 С‚СѓСЂ"),
+            _build_match("d2-2", "Benfica", "Roma", day2, "16:00", "UEFA Europa League. 1/8 С„РёРЅР°Р»Р°"),
+            _build_match("d2-3", "Day2 Team 3", "Day2 Opp 3", day2, "14:00", "Ligue 1. 22 С‚СѓСЂ"),
+        ])
+
+        with caplog.at_level(logging.INFO, logger="sync_matches"):
+            selected = syncer._select_top_matches_with_day_quotas(matches, limit=10)
+
+        assert len(selected) == 10
+        selected_logs = [
+            record.message for record in caplog.records
+            if record.message.startswith("Top3 selected [")
+        ]
+        assert len(selected_logs) == 10
+        assert any("Top3 selected [Q]" in message for message in selected_logs)
+        assert any("Top3 selected [G]" in message for message in selected_logs)
+        assert any("score=" in message for message in selected_logs)
 
 
 class TestCoverageCheck:

--- a/tests/test_user_handlers_topup.py
+++ b/tests/test_user_handlers_topup.py
@@ -196,7 +196,7 @@ def test_handle_check_topup_reports_not_found_donation(monkeypatch):
     assert "пока не найдена" in safe_edit.await_args_list[-1].args[1].lower()
 
 
-def test_handle_check_topup_rejects_insufficient_amount(monkeypatch):
+def test_handle_check_topup_hides_insufficient_amount_fallback(monkeypatch):
     query = FakeQuery("check_topup_TOKN1234ABCD")
     context = FakeContext()
     safe_edit = AsyncMock()
@@ -220,7 +220,9 @@ def test_handle_check_topup_rejects_insufficient_amount(monkeypatch):
 
     run_async(user_handlers.handle_check_topup(query, 42, "TOKN1234ABCD", context))
 
-    assert "недостаточная сумма" in safe_edit.await_args_list[-1].args[1].lower()
+    text = safe_edit.await_args_list[-1].args[1].lower()
+    assert "пока не зачислено" in text
+    assert "недостаточная сумма" not in text
 
 
 def test_handle_check_topup_completes_successfully(monkeypatch):

--- a/user_handlers.py
+++ b/user_handlers.py
@@ -1457,20 +1457,19 @@ async def handle_check_topup(query, user_id, token, context):
     min_acceptable = int(expected_kopeks * 0.85)
 
     if received_kopeks < min_acceptable:
-        received_rub = received_kopeks / 100
-        amount_rub = topup['amount_rub']
         keyboard = [
+            [InlineKeyboardButton("🔄 Проверить ещё раз",
+                                  callback_data=f'check_topup_{token}')],
             [InlineKeyboardButton("✅ Перейти к оплате", url=DA_PROFILE_URL)],
             [InlineKeyboardButton("🏠 В главное меню",
                                   callback_data='back_to_menu')]
         ]
         await safe_edit_message(
             query,
-            f"❌ <b>Недостаточная сумма</b>\n\n"
-            f"Получено: <b>{received_rub:.2f}</b> 💎\n"
-            f"Требуется: <b>{amount_rub}</b> 💎 "
-            f"(с учётом комиссии: от {min_acceptable / 100:.2f} 💎)\n\n"
-            "Пожалуйста, отправьте донат на полную сумму с тем же кодом.",
+            "⏳ <b>Пополнение пока не зачислено</b>\n\n"
+            "Если вы уже отправили донат — подождите 1-2 минуты и нажмите "
+            "«Проверить ещё раз».\n\n"
+            "Если проблема повторяется — обратитесь в поддержку.",
             InlineKeyboardMarkup(keyboard),
             parse_mode='HTML'
         )


### PR DESCRIPTION
## Что сделано

Ветка объединяет несколько связанных изменений вокруг витрины матчей, качества каталога, topup-flow и шумных продовых алертов:

- добавлен динамический профиль бота с автоматическим выбором наиболее интересных футбольных матчей на ближайшие дни;
- вынесена и покрыта тестами логика ранжирования матчей для описания профиля;
- расширена логика `sync_matches.py` проверкой покрытия данных (`coverage_ok` / `coverage_checked_at`) и переоценкой ранее скрытых матчей;
- добавлены/обновлены запросы в `database.py` для работы с видимыми кандидатами профиля и вспомогательными topup-полями;
- уменьшен шум от единичных сетевых ошибок `python-telegram-bot`: теперь PTB `NetworkError` не улетает в alert-чат как `ERROR` при разовом сбое, а эскалируется только серией;
- убран пользовательский fallback про “недостаточную сумму пополнения баланса”, потому что в текущем topup-flow пополнение гибкое и сообщение только путает пользователя;
- актуализированы и расширены тесты под новые сценарии.

## Основные изменения по файлам

### Профиль бота и ранжирование

- добавлен новый модуль `profile_ranking.py`:
  - нормализация названий команд;
  - веса лиг, стадий и пар команд;
  - временной буст для матчей, которые идут сегодня/скоро;
  - итоговый `profile_score`;
  - выбор лучших матчей для описания профиля;
- добавлен `bot_profile.py`:
  - сбор кандидатов из БД;
  - построение текстового описания профиля;
  - обновление description через Bot API;
- `main.py` использует обновление профиля внутри текущих post-init / scheduled job сценариев.

### Coverage и каталог матчей

- в `sync_matches.py` добавлена проверка покрытия данных после синка;
- введена работа с `coverage_ok` и `coverage_checked_at`;
- скрытые по coverage матчи можно перепроверять повторно спустя время;
- в `database.py` добавлены/обновлены запросы для выборки только пригодных матчей в профиль и каталог.

### Topup-flow и пользовательские fallback-сообщения

- в `user_handlers.py` убран fallback “недостаточная сумма пополнения” для topup-сценария;
- вместо этого пользователь получает нейтральное сообщение, что пополнение пока не зачислено и можно повторить проверку позже;
- в `donationalerts_listener.py` убрано аналогичное legacy-уведомление пользователю.

### Продовые алерты PTB

- `main.error_handler` теперь различает обычные исключения PTB и `NetworkError`;
- одиночные сетевые сбои логируются как `warning`;
- `error` и Telegram-alert возникают только после серии подряд и затем редкими напоминаниями при затяжном отказе;
- это уменьшает ложный шум в админском alert-чате при кратковременных сетевых проблемах.

## Зачем это нужно

- сделать описание профиля бота более живым и полезным для витрины;
- не показывать пользователю матчи, по которым не хватает данных для качественной карточки;
- снизить количество шумных продовых алертов по временным сетевым отвалам;
- убрать лишний и вводящий в заблуждение fallback в topup-flow;
- зафиксировать всё это тестами, чтобы изменения не расползлись в следующих правках.

## Тесты

Запущено:

```bash
pytest -q
```

Результат:

- `491 passed`

## Риски и примечания

- PR объединяет не одну точечную правку, а весь текущий набор изменений в ветке;
- часть изменений затрагивает не только пользовательский UX, но и ранжирование каталога / профиль бота / visibility по coverage;
- `donationalerts_listener.py` сейчас не является основным рабочим flow, но legacy-поведение там приведено в соответствие с актуальной логикой topup.
